### PR TITLE
Changed OAuth2 token endpoint to /oauth2/token

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
@@ -117,7 +117,7 @@ public class Constants {
 	public static final String CONFIGURATION_ENDPOINT = SERVER_APP_ENDPOINT + "configuration/";
 	public static final String SCEP_ENDPOINT = "/api/scep-mgt/v" + SERVER_API_VERSION +
 												"/certificates/signcsr";
-	public static final String OAUTH_ENDPOINT = "/token";
+	public static final String OAUTH_ENDPOINT = "/oauth2/token";
 	public static final String DEVICE_ENDPOINT = SERVER_APP_ENDPOINT + "devices/";
 	public static final String IS_REGISTERED_ENDPOINT = "/status";
 	public static final String UNREGISTER_ENDPOINT =  REGISTER_ENDPOINT;


### PR DESCRIPTION
When trying to enroll a device to IOTS 3.0.0, enrollment always fails with the same error that the credentials are wrong. However, in the Logcat there is a Volley error that `/token` returns 302. It appears that this should be `/oauth2/token` and with this change the enrollment moves on correctly.