### PR TITLE
changing configurations to be read from BuildConfig

### DIFF
--- a/client/iDPProxy/src/main/java/org/wso2/iot/agent/proxy/utils/Constants.java
+++ b/client/iDPProxy/src/main/java/org/wso2/iot/agent/proxy/utils/Constants.java
@@ -59,10 +59,10 @@ public class Constants {
 	}
 
 	public static final String SERVER_PROTOCOL = BuildConfig.SERVER_PROTOCOL;
-	public static final String TRUSTSTORE_PASSWORD = "wso2carbon";
-	public static final String KEYSTORE_PASSWORD = "wso2carbon";
-	public static final String TRUSTSTORE_LOCATION = null;
-	public static final String KEYSTORE_LOCATION = null;
+	public static final String TRUSTSTORE_PASSWORD = BuildConfig.TRUSTSTORE_PASSWORD;
+	public static final String KEYSTORE_PASSWORD = BuildConfig.KEYSTORE_PASSWORD;
+	public static final String TRUSTSTORE_LOCATION = BuildConfig.TRUSTSTORE_LOCATION;
+	public static final String KEYSTORE_LOCATION = BuildConfig.KEYSTORE_LOCATION;
 	public static final boolean DEBUG_ENABLED = BuildConfig.DEBUG_MODE_ENABLED;
 	public final static int ACCESS_TOKEN_AGE = 3000;
 


### PR DESCRIPTION
## Purpose
The configurations related to keystores were read from Constants file instead of gradle

## Goals
Moved configs to gradle

## Documentation
Docs were changed
https://docs.wso2.com/display/IoTS310/Generating+a+BKS+File+for+Android#GeneratingaBKSFileforAndroid-Step2:GeneratingaBKSfile

## Training
N/A

## Certification
N/A, This is configs related to agent.

