### PR TITLE
FCM not working due to the message flow synchronization

### DIFF
--- a/client/client/src/main/java/org/wso2/iot/agent/FCMMessagingService.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/FCMMessagingService.java
@@ -41,7 +41,9 @@ public class FCMMessagingService extends FirebaseMessagingService {
 		Log.d(TAG, "New FCM notification.");
 		MessageProcessor messageProcessor = new MessageProcessor(context);
 		try {
-			messageProcessor.getMessages();
+			if (Preference.getBoolean(context, Constants.PreferenceFlag.REGISTERED)) {
+				messageProcessor.getMessages();
+			}
 		} catch (AndroidAgentException e) {
 			Log.e(TAG, "Failed to perform operation", e);
 		}

--- a/client/client/src/main/java/org/wso2/iot/agent/activities/AlreadyRegisteredActivity.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/activities/AlreadyRegisteredActivity.java
@@ -131,6 +131,19 @@ public class AlreadyRegisteredActivity extends AppCompatActivity implements APIR
 			if (!isDeviceAdminActive()) {
 				startEvents();
 			}
+			// In FCM, for fresh registrations, the initial FCM notification has been ignored
+			// purposely to avoid calling the server during enrollment flow and causing threading
+			// issues. Therefore after initial enrollment, pending operations is called manually.
+			if (Constants.NOTIFIER_FCM.equals(Preference.getString(context, Constants.PreferenceFlag.NOTIFIER_TYPE))) {
+				MessageProcessor messageProcessor = new MessageProcessor(context);
+				try {
+					if (Preference.getBoolean(context, Constants.PreferenceFlag.REGISTERED)) {
+						messageProcessor.getMessages();
+					}
+				} catch (AndroidAgentException e) {
+					Log.e(TAG, "Failed to perform operation", e);
+				}
+			}
 			isFreshRegistration = false;
 		}
 
@@ -514,6 +527,7 @@ public class AlreadyRegisteredActivity extends AppCompatActivity implements APIR
 	 */
 	private void initiateUnregistration() {
 		CommonUtils.disableAdmin(context);
+		Preference.putBoolean(context, Constants.PreferenceFlag.REGISTERED, false);
 		loadInitialActivity();
 	}
 

--- a/client/client/src/main/java/org/wso2/iot/agent/activities/RegistrationActivity.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/activities/RegistrationActivity.java
@@ -57,6 +57,9 @@ public class RegistrationActivity extends Activity implements APIResultCallBack 
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_registration);
 		context = this;
+		if (Constants.NOTIFIER_FCM.equals(Preference.getString(context, Constants.PreferenceFlag.NOTIFIER_TYPE))) {
+			registerFCM();
+		}
 		deviceInfoBuilder = new DeviceInfoPayload(context);
 		DeviceInfo deviceInfo = new DeviceInfo(context);
 		String deviceIdentifier = deviceInfo.getDeviceId();
@@ -221,16 +224,13 @@ public class RegistrationActivity extends Activity implements APIResultCallBack 
 				responseStatus = result.get(Constants.STATUS);
 				Preference.putString(context, Constants.PreferenceFlag.REG_ID, info.getDeviceId());
 				if (Constants.Status.SUCCESSFUL.equals(responseStatus) || Constants.Status.CREATED.equals(responseStatus)) {
-					if (Constants.NOTIFIER_FCM.equals(Preference.getString(context, Constants.PreferenceFlag.NOTIFIER_TYPE))) {
-						registerFCM();
+					CommonDialogUtils.stopProgressDialog(progressDialog);
+					if (Constants.OWNERSHIP_COSU.equals(Constants.DEFAULT_OWNERSHIP)) {
+						loadKioskActivity();
 					} else {
-						CommonDialogUtils.stopProgressDialog(progressDialog);
-						if(Constants.OWNERSHIP_COSU.equals(Constants.DEFAULT_OWNERSHIP)){
-							loadKioskActivity();
-						}else{
-							loadAlreadyRegisteredActivity();
-						}
+						loadAlreadyRegisteredActivity();
 					}
+
 				} else {
 					displayInternalServerError();
 				}
@@ -271,11 +271,6 @@ public class RegistrationActivity extends Activity implements APIResultCallBack 
 		String token =  FirebaseInstanceId.getInstance().getToken();
 		if(token != null) {
 			Preference.putString(context, Constants.FCM_REG_ID, token);
-			try {
-				sendRegistrationId();
-			} catch (AndroidAgentException e) {
-				Log.e(TAG, "Error while sending registration Id");
-			}
 		} else {
 			try {
 				CommonUtils.clearAppData(context);

--- a/client/client/src/main/java/org/wso2/iot/agent/events/publisher/HttpDataPublisher.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/events/publisher/HttpDataPublisher.java
@@ -54,12 +54,14 @@ public class HttpDataPublisher implements APIResultCallBack, DataPublisher {
         eventPayload.setDeviceIdentifier(deviceIdentifier);
         try {
             String responsePayload = CommonUtils.toJSON(eventPayload);
-            CommonUtils.callSecuredAPI(context,
-                    utils.getAPIServerURL(context) +
-                            Constants.EVENT_ENDPOINT, org.wso2.iot.agent.proxy.utils.
-                            Constants.HTTP_METHODS.POST,
-                    responsePayload, HttpDataPublisher.this,
-                    Constants.EVENT_REQUEST_CODE);
+            if (Preference.getBoolean(context, Constants.PreferenceFlag.REGISTERED)) {
+                CommonUtils.callSecuredAPI(context,
+                        utils.getAPIServerURL(context) +
+                                Constants.EVENT_ENDPOINT, org.wso2.iot.agent.proxy.utils.
+                                Constants.HTTP_METHODS.POST,
+                        responsePayload, HttpDataPublisher.this,
+                        Constants.EVENT_REQUEST_CODE);
+            }
         } catch (AndroidAgentException e) {
             Log.e(TAG, "Cannot convert event data to JSON");
         }


### PR DESCRIPTION
## Purpose
In FCM, the message delivering order is causing an issue and the device enrollment fails. When the device enrollment request is sent by Android, an FCM request is sent to the device and since the enrollment response is not still received by the device, this causes synchronization issues.

## Goals
Fixing FCM message flow. Fixes wso2/product-iots#1453
