### PR TITLE
Change Requests to Resume interrupted download of over-the-air (OTA)

### DIFF
--- a/system-service/app/src/main/java/org/wso2/iot/system/service/api/OTAServerManager.java
+++ b/system-service/app/src/main/java/org/wso2/iot/system/service/api/OTAServerManager.java
@@ -305,7 +305,7 @@ public class OTAServerManager {
             File targetFile = new File(FileUtils.getUpgradePackageDirectory() + File.separator + oldFileName);
             if (targetFile.exists()) {
                 targetFile.delete();
-                Log.w(TAG, "Old update has been deleted.");
+                Log.i(TAG, "Old update has been deleted.");
             }
         }
 
@@ -326,7 +326,7 @@ public class OTAServerManager {
                 // Set whether this download may proceed over a roaming connection.
                 request.setAllowedOverRoaming(true);
                 // Set the title of this download, to be displayed in notifications
-                if (Constants.OTA_DOWNLOAD_PROGRESS_BAR_ENABLED.equals(true)) {
+                if (Constants.OTA_DOWNLOAD_PROGRESS_BAR_ENABLED) {
                     request.setVisibleInDownloadsUi(true);
                     request.setTitle("Downloading firmware upgrade");
                     request.setDescription("WSO2 Agent");

--- a/system-service/app/src/main/java/org/wso2/iot/system/service/utils/Constants.java
+++ b/system-service/app/src/main/java/org/wso2/iot/system/service/utils/Constants.java
@@ -54,6 +54,7 @@ public class Constants {
 	public static final String SYSTEM_APP_ACTION_RESPONSE = "org.wso2.iot.system.service.MESSAGE_PROCESSED";
 	public static final String AGENT_APP_SERVICE_NAME = "org.wso2.iot.agent.START_SERVICE";
 	public static final String OTA_DOWNLOAD_PROGRESS_BAR_ENABLED = "true";
+	public static final int OTA_DOWNLOAD_PERCENTAGE_FACTOR = 5;
 
 	/**
 	 * Operation IDs

--- a/system-service/app/src/main/java/org/wso2/iot/system/service/utils/Constants.java
+++ b/system-service/app/src/main/java/org/wso2/iot/system/service/utils/Constants.java
@@ -53,7 +53,7 @@ public class Constants {
 	public static final String FIRMWARE_INSTALL_CANCEL_ACTION = "FIRMWARE_INSTALL_CANCEL_ACTION";
 	public static final String SYSTEM_APP_ACTION_RESPONSE = "org.wso2.iot.system.service.MESSAGE_PROCESSED";
 	public static final String AGENT_APP_SERVICE_NAME = "org.wso2.iot.agent.START_SERVICE";
-	public static final String OTA_DOWNLOAD_PROGRESS_BAR_ENABLED = "true";
+	public static final boolean OTA_DOWNLOAD_PROGRESS_BAR_ENABLED = true;
 	public static final int OTA_DOWNLOAD_PERCENTAGE_FACTOR = 5;
 
 	/**

--- a/system-service/app/src/main/java/org/wso2/iot/system/service/utils/FileUtils.java
+++ b/system-service/app/src/main/java/org/wso2/iot/system/service/utils/FileUtils.java
@@ -29,12 +29,15 @@ import java.io.File;
 public class FileUtils {
 
     public static String getUpgradePackageDirectory(){
-        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getPath();
+//        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getPath();
+        return Environment.getDownloadCacheDirectory().getPath();
     }
 
     public static String getUpgradePackageFilePath() {
         String path = getUpgradePackageDirectory();
         Log.d(FileUtils.class.getName(), path + File.separator + Constants.UPDATE_PACKAGE_NAME);
         return getUpgradePackageDirectory() + File.separator + Constants.UPDATE_PACKAGE_NAME;
+//        return getUpgradePackageDirectory() + File.separator + "ota" + File.separator + Constants.UPDATE_PACKAGE_NAME;
+
     }
 }

--- a/system-service/app/src/main/res/values/strings.xml
+++ b/system-service/app/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="txt_lock_activity">Device is locked. Please contact administrator</string>
     <string name="txt_unlock_activity">Device is Unlocked</string>
     <string name="title_activity_lock">LockActivity</string>
+    <string name="firmware_upgrade_file_name_pref">firmwareUpgradeFileName</string>
 </resources>


### PR DESCRIPTION
## Purpose
> Change request to the resume download feature
1. Currently the OTA firmware downloads will be saved in ../Download directory and this PR will change it to the location /cache/
2. Stop creating multiple download files during several calls of the firmware operation
3. Minor changes to the logic of the firmware download. 