### PR TITLE
Change Requests fixes to Resume interrupted download of over-the-air

### DIFF
--- a/system-service/app/src/main/java/org/wso2/iot/system/service/utils/Constants.java
+++ b/system-service/app/src/main/java/org/wso2/iot/system/service/utils/Constants.java
@@ -55,6 +55,7 @@ public class Constants {
 	public static final String AGENT_APP_SERVICE_NAME = "org.wso2.iot.agent.START_SERVICE";
 	public static final boolean OTA_DOWNLOAD_PROGRESS_BAR_ENABLED = true;
 	public static final int OTA_DOWNLOAD_PERCENTAGE_FACTOR = 5;
+	public static final int FIRMWARE_DOWNLOAD_TIMEOUT = 2*60*1000;
 
 	/**
 	 * Operation IDs

--- a/system-service/app/src/main/java/org/wso2/iot/system/service/utils/FileUtils.java
+++ b/system-service/app/src/main/java/org/wso2/iot/system/service/utils/FileUtils.java
@@ -36,8 +36,12 @@ public class FileUtils {
     public static String getUpgradePackageFilePath() {
         String path = getUpgradePackageDirectory();
         Log.d(FileUtils.class.getName(), path + File.separator + Constants.UPDATE_PACKAGE_NAME);
-        return getUpgradePackageDirectory() + File.separator + Constants.UPDATE_PACKAGE_NAME;
-//        return getUpgradePackageDirectory() + File.separator + "ota" + File.separator + Constants.UPDATE_PACKAGE_NAME;
+//        return getUpgradePackageDirectory() + File.separator + Constants.UPDATE_PACKAGE_NAME;
+        return getUpgradePackageDirectory() + File.separator + "ota" + File.separator + Constants.UPDATE_PACKAGE_NAME;
+    }
 
+    public static String getOTAPackageFilePath() {
+        String path = getUpgradePackageDirectory();
+        return getUpgradePackageDirectory() + File.separator + "ota";
     }
 }


### PR DESCRIPTION
## Purpose
> Change request to the resume download feature

1. Handle the /cache clearance in backwards compatible way
2. OTA firmware downloads will be saved in /cache/ota/
3. Handled the connection failures, timeouts when downloading the update package
4. Minor changes to the logic of the firmware download

