### PR TITLE
Change requests to resume interrupted download of over-the-air (OTA)

### DIFF
--- a/client/client/build.gradle
+++ b/client/client/build.gradle
@@ -25,19 +25,32 @@ repositories {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24.0.0"
 
     defaultConfig {
         applicationId "org.wso2.emm.agent"
-        minSdkVersion 17
-        targetSdkVersion 23
+        minSdkVersion 22
+        targetSdkVersion 22
         multiDexEnabled true
     }
 
+    signingConfigs {
+        config {
+            keyAlias 'platform'
+            keyPassword 'android'
+            storeFile file('../../swordfish.keystore')
+            storePassword 'android'
+        }
+    }
+
     buildTypes {
+        debug{
+            signingConfig signingConfigs.config
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            signingConfig signingConfigs.config
 
             applicationVariants.all { variant ->
                 variant.outputs.each { output ->

--- a/client/client/src/main/AndroidManifest.xml
+++ b/client/client/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.wso2.emm.agent"
-    android:sharedUserId="org.wso2.emm.agent"
+    android:sharedUserId="android.uid.system"
     android:versionCode="2"
     android:versionName="2.0">
 

--- a/client/client/src/main/java/org/wso2/emm/agent/services/ApplicationManagementService.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/ApplicationManagementService.java
@@ -166,6 +166,19 @@ public class ApplicationManagementService extends IntentService implements APIRe
                 sendBroadcast(Constants.Status.SUCCESSFUL, Preference.getString(context, context.getResources().
                         getString(R.string.app_download_progress)));
                 break;
+            case Constants.Operation.FIRMWARE_IMAGE_DOWNLOADING:
+                Preference.putInt(context, context.getResources().
+                        getString(R.string.firmware_upgrade_retries), 0);
+                Preference.putString(context, context.getResources().
+                        getString(R.string.firmware_upgrade_response_message), message);
+                Preference.putString(context, context.getResources().
+                        getString(R.string.firmware_upgrade_response_status), context.getResources().getString(
+                        R.string.operation_value_progress));
+                Preference.putInt(context, context.getResources().
+                        getString(R.string.firmware_upgrade_response_id), id);
+                Preference.putBoolean(context, context.getResources().
+                        getString(R.string.firmware_upgrade_retry_pending), false);
+                break;
             case Constants.Operation.FIRMWARE_UPGRADE_COMPLETE:
             case Constants.Operation.FIRMWARE_INSTALLATION_CANCELED:
                 Preference.putInt(context, context.getResources().

--- a/client/client/src/main/java/org/wso2/emm/agent/utils/CommonUtils.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/utils/CommonUtils.java
@@ -417,9 +417,9 @@ public class CommonUtils {
 									.getString(R.string.firmware_upgrade_automatic_retry)));
 						} else {
 							upgradeData.put(context.getResources()
-									.getString(R.string.firmware_upgrade_automatic_retry), true);
+									.getString(R.string.firmware_upgrade_automatic_retry), false);
 							Preference.putBoolean(context, context.getResources()
-									.getString(R.string.is_automatic_firmware_upgrade), true);
+									.getString(R.string.is_automatic_firmware_upgrade), false);
 							Log.d(TAG, "Updated payload: " + command);
 						}
 					} catch (JSONException e) {

--- a/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
@@ -28,7 +28,7 @@ public class Constants {
 	public static final boolean DEBUG_MODE_ENABLED = true;
 	public static final boolean LOCAL_NOTIFICATIONS_ENABLED = true;
 	public static final boolean GCM_ENABLED = false;
-	public static final boolean SYSTEM_APP_ENABLED = false;
+	public static final boolean SYSTEM_APP_ENABLED = true;
 	public static final boolean AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED = false;
 	public static final boolean ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE = false;
 	public static final String SYSTEM_APP_SERVICE_START_ACTION = "org.wso2.emm.system.service.START_SERVICE";
@@ -55,7 +55,7 @@ public class Constants {
 	public static final String APP_MANAGER_HOST = null;
 	public static final String SYSTEM_SERVICE_PACKAGE = "org.wso2.emm.system.service";
 	public static final String AGENT_PACKAGE = "org.wso2.emm.agent";
-	public static final int FIRMWARE_UPGRADE_RETRY_COUNT = 5;
+	public static final int FIRMWARE_UPGRADE_RETRY_COUNT = 0;
 	public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
 
 

--- a/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
@@ -18,6 +18,7 @@
 
 package org.wso2.emm.agent.utils;
 
+import android.app.Service;
 import android.util.Log;
 
 /**
@@ -340,6 +341,7 @@ public class Constants {
 		public static final String GET_FIRMWARE_UPGRADE_DOWNLOAD_PROGRESS = "FIRMWARE_UPGRADE_DOWNLOAD_PROGRESS";
 		public static final String FAILED_FIRMWARE_UPGRADE_NOTIFICATION = "FAILED_FIRMWARE_UPGRADE_NOTIFICATION";
 		public static final String FIRMWARE_UPGRADE_COMPLETE = "FIRMWARE_UPGRADE_COMPLETE";
+		public static final String FIRMWARE_IMAGE_DOWNLOADING = "FIRMWARE_IMAGE_DOWNLOADING";
 		public static final String FIRMWARE_UPGRADE_FAILURE = "FIRMWARE_UPGRADE_FAILURE";
 		public static final String FIRMWARE_INSTALLATION_CANCELED = "FIRMWARE_INSTALLATION_CANCELED";
 		public static final String GET_FIRMWARE_BUILD_DATE = "FIRMWARE_BUILD_DATE";

--- a/client/iDPProxy/build.gradle
+++ b/client/iDPProxy/build.gradle
@@ -17,18 +17,31 @@
  */
 apply plugin: 'com.android.library'
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "24.0.0"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion 22
+        targetSdkVersion 23
+    }
+
+    signingConfigs {
+        config {
+            keyAlias 'platform'
+            keyPassword 'android'
+            storeFile file('../../swordfish.keystore')
+            storePassword 'android'
+        }
     }
 
     buildTypes {
+        debug{
+            signingConfig signingConfigs.config
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            signingConfig signingConfigs.config
         }
     }
     compileOptions {

--- a/client/iDPProxy/src/main/AndroidManifest.xml
+++ b/client/iDPProxy/src/main/AndroidManifest.xml
@@ -21,14 +21,4 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="22" />
-
-    <application
-        android:allowBackup="true"
-        android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name">
-    </application>
-
 </manifest>

--- a/system-service/app/build.gradle
+++ b/system-service/app/build.gradle
@@ -29,7 +29,6 @@ android {
         versionName "1.0"
     }
 
-
     buildTypes {
         release {
             minifyEnabled false
@@ -43,4 +42,5 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.2.1'
     compile 'commons-io:commons-io:2.4'
+    compile 'com.google.code.gson:gson:2.8.0'
 }

--- a/system-service/app/build.gradle
+++ b/system-service/app/build.gradle
@@ -29,19 +29,8 @@ android {
         versionName "1.0"
     }
 
-    signingConfigs {
-        config {
-            keyAlias 'platform'
-            keyPassword 'android'
-            storeFile file('../../swordfish.keystore')
-            storePassword 'android'
-        }
-    }
 
     buildTypes {
-        debug{
-            signingConfig signingConfigs.config
-        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/system-service/app/build.gradle
+++ b/system-service/app/build.gradle
@@ -19,19 +19,33 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "21.1.2"
+    buildToolsVersion "24.0.0"
 
     defaultConfig {
         applicationId "org.wso2.emm.system.service"
-        minSdkVersion 17
-        targetSdkVersion 23
+        minSdkVersion 22
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }
+
+    signingConfigs {
+        config {
+            keyAlias 'platform'
+            keyPassword 'android'
+            storeFile file('../../swordfish.keystore')
+            storePassword 'android'
+        }
+    }
+
     buildTypes {
+        debug{
+            signingConfig signingConfigs.config
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.config
         }
     }
 }
@@ -39,4 +53,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.2.1'
+    compile 'commons-io:commons-io:2.4'
 }

--- a/system-service/app/src/main/AndroidManifest.xml
+++ b/system-service/app/src/main/AndroidManifest.xml
@@ -54,6 +54,7 @@
                 <action android:name="org.wso2.emm.system.service.START_SERVICE" />
             </intent-filter>
         </service>
+        <service android:name=".services.OTADownloadService" />
 
         <activity
                 android:name=".MainActivity"

--- a/system-service/app/src/main/AndroidManifest.xml
+++ b/system-service/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
  ~ specific language governing permissions and limitations
  ~ under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.wso2.emm.system.service"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.wso2.emm.system.service"
     android:sharedUserId="android.uid.system">
 
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
@@ -34,7 +35,7 @@
     <uses-permission android:name="android.permission.ACCESS_SUPERUSER" />
     <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.MASTER_CLEAR"/>
+    <uses-permission android:name="android.permission.MASTER_CLEAR" />
 
     <permission android:name="org.wso2.emm.system.service.permission.ACCESS"
         android:protectionLevel="signature"></permission>
@@ -105,7 +106,6 @@
                 android:name="org.wso2.emm.system.service.ServiceDeviceAdminReceiver"
                 android:permission="android.permission.BIND_DEVICE_ADMIN">
             <intent-filter>
-
                 <!-- This action is required -->
                 <action android:name="android.app.action.DEVICE_ADMIN_ENABLED"/>
             </intent-filter>

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/api/OTADownload.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/api/OTADownload.java
@@ -78,6 +78,10 @@ public class OTADownload implements OTAServerManager.OTAStateChangeListener {
         }
     }
 
+    public OTAServerManager getOtaServerManager(){
+        return otaServerManager;
+    }
+
     /**
      * Returns the byte count in a human readable format.
      *

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/api/OTAServerManager.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/api/OTAServerManager.java
@@ -504,7 +504,6 @@ public class OTAServerManager {
                             //This will setup a total time for the upgrade firmware operation. Firmware operation needs to be
                             //completed within this time limit otherwise the operation will be aborted.
                             if ((Calendar.getInstance().getTime().getTime() - startTimeStamp) > Constants.FIRMWARE_DOWNLOAD_TIMEOUT) {
-                                Log.e(TAG, "timeout-timeout-timeout-timeout-timeout-timeout-timeout-timeout");
                                 downloadManager.remove(downloadReference);
                                 Preference.putBoolean(context, context.getResources().getString(R.string.download_manager_reference_id_available), false);
                                 Preference.putLong(context, context.getResources().getString(R.string.download_manager_reference_id), -1);
@@ -540,7 +539,6 @@ public class OTAServerManager {
                                 break;
                             } else if (cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)) == DownloadManager.
                                     STATUS_SUCCESSFUL) {
-                                Log.e(TAG, "successful-successful-successful-successful-successful-successful-successful-successful");
                                 Preference.putBoolean(context, context.getResources().getString(R.string.download_manager_reference_id_available), false);
                                 Preference.putLong(context, context.getResources().getString(R.string.download_manager_reference_id), -1);
                                 cursor.close();
@@ -555,7 +553,6 @@ public class OTAServerManager {
                                 break;
                             } else if (cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)) == DownloadManager.
                                     STATUS_PAUSED) {
-                                Log.e(TAG, "paused-paused-paused-paused-paused-paused-paused-paused-paused-paused-paused");
                                 if (!isPaused) {
                                     int reason = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON));
                                     String reasonString = "Unknown";
@@ -579,8 +576,6 @@ public class OTAServerManager {
                                 cursor.close();
                             } else if (cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)) == DownloadManager.
                                     STATUS_FAILED) {
-                                Log.e(TAG, "failed-failed-failed-failed-failed-failed-failed-failed-failed");
-
                                 downloadManager.remove(downloadReference);
                                 Preference.putBoolean(context, context.getResources().getString(R.string.download_manager_reference_id_available), false);
                                 Preference.putLong(context, context.getResources().getString(R.string.download_manager_reference_id), -1);

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/services/DeviceStartupIntentReceiver.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/services/DeviceStartupIntentReceiver.java
@@ -44,9 +44,8 @@ public class DeviceStartupIntentReceiver extends BroadcastReceiver {
 	public void onReceive(final Context context, Intent intent) {
 
 		if ("android.intent.action.BOOT_COMPLETED".equals(intent.getAction())) {
-			Log.d(TAG, "Download manager reference id availability -----------------------------------------------------------:");
 			Intent pushIntent = new Intent(context, OTADownloadService.class);
-				context.startService(pushIntent);
+			context.startService(pushIntent);
 		}
 
 		if (intent.hasExtra(context.getResources().getString(R.string.alarm_scheduled_operation))) {
@@ -57,12 +56,12 @@ public class DeviceStartupIntentReceiver extends BroadcastReceiver {
 		int interval = Preference.getInt(context, resources.getString(R.string.alarm_interval));
 		String oneTimeAlarm = Preference.getString(context, resources.getString(R.string.alarm_schedule));
 
-		if(interval > 0) {
+		if (interval > 0) {
 			AlarmUtils.setRecurringAlarm(context.getApplicationContext(), interval);
 		}
 
-		if(oneTimeAlarm != null && !oneTimeAlarm.trim().isEmpty()) {
-			try{
+		if (oneTimeAlarm != null && !oneTimeAlarm.trim().isEmpty()) {
+			try {
 				if (operation != null && operation.trim().equals(Constants.Operation.UPGRADE_FIRMWARE)) {
 					AlarmUtils.setOneTimeAlarm(context, oneTimeAlarm, Constants.Operation.UPGRADE_FIRMWARE, null);
 				}

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/services/DeviceStartupIntentReceiver.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/services/DeviceStartupIntentReceiver.java
@@ -44,13 +44,9 @@ public class DeviceStartupIntentReceiver extends BroadcastReceiver {
 	public void onReceive(final Context context, Intent intent) {
 
 		if ("android.intent.action.BOOT_COMPLETED".equals(intent.getAction())) {
-			boolean isAvailabledownloadReference = Preference.getBoolean(context, context.getResources().getString(R.string.download_manager_reference_id_available));
-			Log.d(TAG, "Download manager reference id availability -----------------------------------------------------------: "+isAvailabledownloadReference);
-			if(isAvailabledownloadReference){
-				OTADownload otaDownload = new OTADownload(context);
-				OTAServerManager otaServerManager = otaDownload.getOtaServerManager();
-				otaServerManager.startDownloadUpgradePackage(otaServerManager);
-			}
+			Log.d(TAG, "Download manager reference id availability -----------------------------------------------------------:");
+			Intent pushIntent = new Intent(context, OTADownloadService.class);
+				context.startService(pushIntent);
 		}
 
 		if (intent.hasExtra(context.getResources().getString(R.string.alarm_scheduled_operation))) {

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/services/DeviceStartupIntentReceiver.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/services/DeviceStartupIntentReceiver.java
@@ -21,8 +21,11 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
+import android.os.Debug;
 import android.util.Log;
 import org.wso2.emm.system.service.R;
+import org.wso2.emm.system.service.api.OTADownload;
+import org.wso2.emm.system.service.api.OTAServerManager;
 import org.wso2.emm.system.service.utils.AlarmUtils;
 import org.wso2.emm.system.service.utils.Constants;
 import org.wso2.emm.system.service.utils.Preference;
@@ -39,6 +42,17 @@ public class DeviceStartupIntentReceiver extends BroadcastReceiver {
 
 	@Override
 	public void onReceive(final Context context, Intent intent) {
+
+		if ("android.intent.action.BOOT_COMPLETED".equals(intent.getAction())) {
+			boolean isAvailabledownloadReference = Preference.getBoolean(context, context.getResources().getString(R.string.download_manager_reference_id_available));
+			Log.d(TAG, "Download manager reference id availability -----------------------------------------------------------: "+isAvailabledownloadReference);
+			if(isAvailabledownloadReference){
+				OTADownload otaDownload = new OTADownload(context);
+				OTAServerManager otaServerManager = otaDownload.getOtaServerManager();
+				otaServerManager.startDownloadUpgradePackage(otaServerManager);
+			}
+		}
+
 		if (intent.hasExtra(context.getResources().getString(R.string.alarm_scheduled_operation))) {
 			operation = intent.getStringExtra(context.getResources().getString(R.string.alarm_scheduled_operation));
 		}

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/services/OTADownloadService.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/services/OTADownloadService.java
@@ -1,0 +1,40 @@
+package org.wso2.emm.system.service.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+import org.wso2.emm.system.service.R;
+import org.wso2.emm.system.service.api.OTADownload;
+import org.wso2.emm.system.service.api.OTAServerManager;
+import org.wso2.emm.system.service.utils.Preference;
+
+/**
+ *
+ */
+
+public class OTADownloadService extends Service {
+
+    private static final String TAG = OTADownloadService.class.getName();
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId){
+        boolean isAvailabledownloadReference = Preference.getBoolean(this, this.getResources().getString(R.string.download_manager_reference_id_available));
+        Log.d(TAG, "Download manager reference id availability -----------------------------------------------------------: "+isAvailabledownloadReference);
+        if(isAvailabledownloadReference){
+            OTADownload otaDownload = new OTADownload(this);
+            OTAServerManager otaServerManager = otaDownload.getOtaServerManager();
+            otaServerManager.startDownloadUpgradePackage(otaServerManager);
+        } else{
+            stopSelf();
+        }
+        return Service.START_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent){
+        return null;
+
+    }
+}

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/services/OTADownloadService.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/services/OTADownloadService.java
@@ -11,7 +11,8 @@ import org.wso2.emm.system.service.api.OTAServerManager;
 import org.wso2.emm.system.service.utils.Preference;
 
 /**
- *
+ * This service will start the download monitoring thread by invoking the startDownloadUpgradePackage()
+ * method after a reboot
  */
 
 public class OTADownloadService extends Service {
@@ -19,22 +20,21 @@ public class OTADownloadService extends Service {
     private static final String TAG = OTADownloadService.class.getName();
 
     @Override
-    public int onStartCommand(Intent intent, int flags, int startId){
+    public int onStartCommand(Intent intent, int flags, int startId) {
         boolean isAvailabledownloadReference = Preference.getBoolean(this, this.getResources().getString(R.string.download_manager_reference_id_available));
-        Log.d(TAG, "Download manager reference id availability -----------------------------------------------------------: "+isAvailabledownloadReference);
-        if(isAvailabledownloadReference){
+        Log.d(TAG, "Download manager reference id availability: " + isAvailabledownloadReference);
+        if (isAvailabledownloadReference) {
             OTADownload otaDownload = new OTADownload(this);
             OTAServerManager otaServerManager = otaDownload.getOtaServerManager();
             otaServerManager.startDownloadUpgradePackage(otaServerManager);
-        } else{
+        } else {
             stopSelf();
         }
         return Service.START_STICKY;
     }
 
     @Override
-    public IBinder onBind(Intent intent){
+    public IBinder onBind(Intent intent) {
         return null;
-
     }
 }

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/services/OTADownloadService.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/services/OTADownloadService.java
@@ -22,11 +22,28 @@ public class OTADownloadService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         boolean isAvailabledownloadReference = Preference.getBoolean(this, this.getResources().getString(R.string.download_manager_reference_id_available));
+        int downloadManagerSuccessState = Preference.getInt(this, this.getResources().getString(R.string.download_manager_success_state));
+        int downloadManagerDefaultErrorCode = Preference.getInt(this, this.getResources().getString(R.string.download_manager_default_error_code));
+        int downloadManagerDefaultStateInfoCode = Preference.getInt(this, this.getResources().getString(R.string.download_manager_default_state_info_code));
+        boolean downloadManagerCompletionSuccessful = Preference.getBoolean(this, this.getResources().getString(R.string.download_manager_completion_successful));
+        boolean verificationStartFlag = Preference.getBoolean(this, this.getResources().getString(R.string.verification_start_flag));
+        boolean packageInstallationStartFlag = Preference.getBoolean(this, this.getResources().getString(R.string.package_installation_start_flag));
         Log.d(TAG, "Download manager reference id availability: " + isAvailabledownloadReference);
+
         if (isAvailabledownloadReference) {
             OTADownload otaDownload = new OTADownload(this);
             OTAServerManager otaServerManager = otaDownload.getOtaServerManager();
             otaServerManager.startDownloadUpgradePackage(otaServerManager);
+        } else if (downloadManagerCompletionSuccessful && !verificationStartFlag) {
+            OTADownload otaDownload = new OTADownload(this);
+            OTAServerManager otaServerManager = otaDownload.getOtaServerManager();
+            OTAServerManager.OTAStateChangeListener otaStateChangeListener = otaServerManager.getOTAStateChangeListener();
+            otaStateChangeListener.onStateOrProgress(downloadManagerSuccessState,
+                    downloadManagerDefaultErrorCode, null, downloadManagerDefaultStateInfoCode);
+        } else if (downloadManagerCompletionSuccessful && !packageInstallationStartFlag) {
+            OTADownload otaDownload = new OTADownload(this);
+            OTAServerManager otaServerManager = otaDownload.getOtaServerManager();
+            otaServerManager.startInstallUpgradePackage();
         } else {
             stopSelf();
         }

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/utils/Constants.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/utils/Constants.java
@@ -40,7 +40,7 @@ public class Constants {
 	public static final String OPERATION = "operation";
 	public static final String SYSTEM_APP_ACTION_RESPONSE = "org.wso2.emm.system.service.MESSAGE_PROCESSED";
 	public static final String AGENT_APP_SERVICE_NAME = "org.wso2.emm.agent.START_SERVICE";
-	public static final boolean DEBUG_MODE_ENABLED = false;
+	public static final boolean DEBUG_MODE_ENABLED = true;
 	public static final String ADMIN_MESSAGE = "message";
 	public static final String IS_LOCKED = "lock";
 	public static final int FIRMWARE_UPGRADE_CONNECTIVITY_TIMEOUT = 10000;
@@ -49,7 +49,7 @@ public class Constants {
 	public static final String FIRMWARE_INSTALL_CANCEL_ACTION = "FIRMWARE_INSTALL_CANCEL_ACTION";
 	public static final boolean SILENT_FIRMWARE_INSTALLATION = true;
 	public static final boolean OTA_DOWNLOAD_PROGRESS_BAR_ENABLED = true;
-	public static final int OTA_DOWNLOAD_PERCENTAGE_FACTOR = 5;
+	public static final int OTA_DOWNLOAD_PERCENTAGE_FACTOR = 2;
 	public static final int FIRMWARE_DOWNLOAD_TIMEOUT = 10*60*1000; //Time in milliseconds(Example 10 minutes).
 	/**
 	 * Read_TIMEOUT = SO timeout(the time since the last byte has been received)
@@ -118,6 +118,7 @@ public class Constants {
 		public static final String WIPE_DATA = "WIPE_DATA";
 		public static final String FAILED_FIRMWARE_UPGRADE_NOTIFICATION = "FAILED_FIRMWARE_UPGRADE_NOTIFICATION";
 		public static final String FIRMWARE_UPGRADE_COMPLETE = "FIRMWARE_UPGRADE_COMPLETE";
+		public static final String FIRMWARE_IMAGE_DOWNLOADING = "FIRMWARE_IMAGE_DOWNLOADING";
 		public static final String FIRMWARE_UPGRADE_FAILURE = "FIRMWARE_UPGRADE_FAILURE";
 		public static final String GET_FIRMWARE_BUILD_DATE = "FIRMWARE_BUILD_DATE";
 		public static final String FIRMWARE_INSTALLATION_CANCELED = "FIRMWARE_INSTALLATION_CANCELED";

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/utils/Constants.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/utils/Constants.java
@@ -49,6 +49,8 @@ public class Constants {
 	public static final String FIRMWARE_INSTALL_CANCEL_ACTION = "FIRMWARE_INSTALL_CANCEL_ACTION";
 	public static final boolean SILENT_FIRMWARE_INSTALLATION = true;
 	public static final boolean OTA_DOWNLOAD_PROGRESS_BAR_ENABLED = true;
+	public static final int OTA_DOWNLOAD_PERCENTAGE_FACTOR = 5;
+	public static final int FIRMWARE_DOWNLOAD_TIMEOUT = 10*60*1000; //Time in milliseconds(Example 10 minutes).
 	/**
 	 * Read_TIMEOUT = SO timeout(the time since the last byte has been received)
 	 */

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/utils/FileUtils.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/utils/FileUtils.java
@@ -29,12 +29,19 @@ import java.io.File;
 public class FileUtils {
 
     public static String getUpgradePackageDirectory(){
-        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getPath();
+//        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getPath();
+        return Environment.getDownloadCacheDirectory().getPath();
     }
 
     public static String getUpgradePackageFilePath() {
         String path = getUpgradePackageDirectory();
         Log.d(FileUtils.class.getName(), path + File.separator + Constants.UPDATE_PACKAGE_NAME);
-        return getUpgradePackageDirectory() + File.separator + Constants.UPDATE_PACKAGE_NAME;
+//        return getUpgradePackageDirectory() + File.separator + Constants.UPDATE_PACKAGE_NAME;
+        return getUpgradePackageDirectory() + File.separator + "ota" + File.separator + Constants.UPDATE_PACKAGE_NAME;
+    }
+
+    public static String getOTAPackageFilePath() {
+        String path = getUpgradePackageDirectory();
+        return getUpgradePackageDirectory() + File.separator + "ota";
     }
 }

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/utils/Preference.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/utils/Preference.java
@@ -13,6 +13,37 @@ public class Preference {
 	private static final int DEFAULT_INDEX = 0;
 
 	/**
+	 * Put float data to shared preferences in private mode.
+	 * @param context - The context of activity which is requesting to put data.
+	 * @param key     - Used to identify the value.
+	 * @param value   - The actual value to be saved.
+	 */
+	public static void putLong(Context context, String key, long value) {
+		SharedPreferences mainPref =
+				context.getSharedPreferences(context.getResources()
+								.getString(R.string.shared_pref_package),
+						Context.MODE_PRIVATE
+				);
+		Editor editor = mainPref.edit();
+		editor.putLong(key, value);
+		editor.commit();
+	}
+
+	/**
+	 * Retrieve float data from shared preferences in private mode.
+	 * @param context - The context of activity which is requesting to put data.
+	 * @param key     - Used to identify the value to to be retrieved.
+	 */
+	public static long getLong(Context context, String key) {
+		SharedPreferences mainPref =
+				context.getSharedPreferences(context.getResources()
+								.getString(R.string.shared_pref_package),
+						Context.MODE_PRIVATE
+				);
+		return mainPref.getLong(key, DEFAULT_INDEX);
+	}
+
+	/**
 	 * Put string data to shared preferences in private mode.
 	 * @param context - The context of activity which is requesting to put data.
 	 * @param key     - Used to identify the value.

--- a/system-service/app/src/main/res/values/strings.xml
+++ b/system-service/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="app_name">WSO2 IoT System Service</string>
-    <string name="shared_pref_package">org.wso2.iot.system.service</string>
+    <string name="app_name">WSO2 EMM System Service</string>
+    <string name="shared_pref_package">org.wso2.emm.system.service</string>
     <string name="device_admin_enable_alert">Please Press activate again.</string>
     <string name="alarm_interval">interval</string>
     <string name="alarm_schedule">schedule</string>
@@ -10,6 +10,7 @@
     <string name="app_uri">packageUri</string>
     <string name="verification_failed_flag">isVerificationFailed</string>
     <string name="firmware_download_progress">publishedProgress</string>
+    <string name="firmware_download_progress_map">firmwareDownloadProgressMap</string>
     <string name="operation_id">operationId</string>
     <string name="firmware_status_check_in_progress">firmwareStatusCheck</string>
     <string name="alarm_scheduled_operation">scheduledOperation</string>
@@ -26,4 +27,10 @@
     <string name="download_manager_reference_id">downloadManagerReferenceId</string>
     <string name="download_manager_start_time">downloadManagerStartTime</string>
     <string name="download_manager_reference_id_available">downloadManagerReferenceIdAvailable</string>
+    <string name="download_manager_success_state">downloadManagerSuccessState</string>
+    <string name="download_manager_default_error_code">downloadManagerDefaultErrorCode</string>
+    <string name="download_manager_default_state_info_code">downloadManagerDefaultStateInfoCode</string>
+    <string name="download_manager_completion_successful">downloadManagerCompletionSuccessful</string>
+    <string name="verification_start_flag">verificationStartFlag</string>
+    <string name="package_installation_start_flag">packageInstallationStartFlag</string>
 </resources>

--- a/system-service/app/src/main/res/values/strings.xml
+++ b/system-service/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="app_name">WSO2 EMM System Service</string>
-    <string name="shared_pref_package">org.wso2.emm.system.service</string>
+    <string name="app_name">WSO2 IoT System Service</string>
+    <string name="shared_pref_package">org.wso2.iot.system.service</string>
     <string name="device_admin_enable_alert">Please Press activate again.</string>
     <string name="alarm_interval">interval</string>
     <string name="alarm_schedule">schedule</string>
@@ -22,4 +22,8 @@
     <string name="txt_lock_activity">Device is locked. Please contact administrator</string>
     <string name="txt_unlock_activity">Device is Unlocked</string>
     <string name="title_activity_lock">LockActivity</string>
+    <string name="firmware_upgrade_file_name_pref">firmwareUpgradeFileName</string>
+    <string name="download_manager_reference_id">downloadManagerReferenceId</string>
+    <string name="download_manager_start_time">downloadManagerStartTime</string>
+    <string name="download_manager_reference_id_available">downloadManagerReferenceIdAvailable</string>
 </resources>


### PR DESCRIPTION
## Purpose
> Change request to the resume download feature. This PR consists of;

1. Changes to /cache, /cache/ota directory clearance logic
2. Handled the connection failures, timeouts when downloading the update package (Additionally included download over ethernet)
3. Minor modifications to the logic of the firmware download 