### PR TITLE
Fix for sending 'Complete' status when lower version is OTA'ed

### DIFF
--- a/system-service/app/src/main/java/org/wso2/iot/system/service/api/OTADownload.java
+++ b/system-service/app/src/main/java/org/wso2/iot/system/service/api/OTADownload.java
@@ -171,7 +171,7 @@ public class OTADownload implements OTAServerManager.OTAStateChangeListener {
                 }
                 String message = "Software is up to date:" + Build.VERSION.RELEASE + ", " + Build.ID;
                 Log.i(TAG, message);
-                CommonUtils.callAgentApp(context, Constants.Operation.FIRMWARE_UPGRADE_COMPLETE, Preference.getInt(
+                CommonUtils.callAgentApp(context, Constants.Operation.FIRMWARE_UPGRADE_FAILURE, Preference.getInt(
                         context, context.getResources().getString(R.string.operation_id)), "No upgrades available. " + message);
             } else if (checkNetworkOnline()) {
                 new AsyncTask<Void, Void, Long>() {


### PR DESCRIPTION
## Purpose
> This is to fix sending 'complete' status instead of 'error' when lower firmware version is OTA'ed.  Resolves https://github.com/wso2/product-iots/issues/1515