### PR TITLE
Fixing Bugs related to ring operation and wifi operation

### DIFF
--- a/client/client/src/main/java/org/wso2/iot/agent/AlertActivity.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/AlertActivity.java
@@ -229,7 +229,7 @@ public class AlertActivity extends Activity {
 				if (defaultRingtone != null) {
 					if (deviceInfo.getSdkVersion() >= Build.VERSION_CODES.LOLLIPOP) {
 						AudioAttributes attributes = new AudioAttributes.Builder().
-								setUsage(AudioAttributes.USAGE_NOTIFICATION).
+								setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE).
 								setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION).
 								build();
 						defaultRingtone.setAudioAttributes(attributes);

--- a/client/client/src/main/java/org/wso2/iot/agent/api/WiFiConfig.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/api/WiFiConfig.java
@@ -385,7 +385,7 @@ public class WiFiConfig {
         List<WifiConfiguration> configuredNetworks = wifiManager.getConfiguredNetworks();
         boolean isAvailable = false;
         for (WifiConfiguration configuration : configuredNetworks) {
-            if (configuration.SSID.equals(ssid)) {
+            if (configuration.SSID.equals(ssid) || configuration.SSID.equals("\"" + ssid + "\"")) {
                 isAvailable = true;
                 break;
             }

--- a/client/client/src/main/java/org/wso2/iot/agent/services/PolicyRevokeHandler.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/PolicyRevokeHandler.java
@@ -132,7 +132,8 @@ public class PolicyRevokeHandler {
                 case Constants.Operation.RUNTIME_PERMISSION_POLICY:
                     revokeRunTimePermissionPolicyOperation(operation);
                 default:
-                    throw new AndroidAgentException("Invalid operation code received");
+                    Log.e(TAG, "Operation code: " + operation.getCode() + " is not supported");
+                    //throw new AndroidAgentException("Invalid operation code received");
             }
         } else {
             switch (operation.getCode()) {
@@ -204,7 +205,8 @@ public class PolicyRevokeHandler {
                     revokeCOSUProfilePolicy(operation);
                     break;
                 default:
-                    throw new AndroidAgentException("Invalid operation code received");
+                    Log.e(TAG, "Operation code: " + operation.getCode() + " is not supported");
+                    //throw new AndroidAgentException("Invalid operation code received");
             }
         }
     }

--- a/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManager.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManager.java
@@ -316,7 +316,7 @@ public abstract class OperationManager implements APIResultCallBack, VersionBase
         intent.putExtra(resources.getString(R.string.intent_extra_message_text),
                 resources.getString(R.string.intent_extra_stop_ringing));
         intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP |
-                Intent.FLAG_ACTIVITY_NEW_TASK);
+                Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
         context.startActivity(intent);
 
         if (Constants.DEBUG_MODE_ENABLED) {

--- a/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManagerBYOD.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManagerBYOD.java
@@ -179,19 +179,28 @@ public class OperationManagerBYOD extends OperationManager {
 
     @Override
     public void clearPassword(Operation operation) {
-        operation.setStatus(getContextResources().getString(R.string.operation_value_completed));
-        getResultBuilder().build(operation);
-
-        getDevicePolicyManager().setPasswordQuality(getCdmDeviceAdmin(),
-                DevicePolicyManager.PASSWORD_QUALITY_UNSPECIFIED);
-        getDevicePolicyManager().setPasswordMinimumLength(getCdmDeviceAdmin(), getDefaultPasswordLength());
-        getDevicePolicyManager().resetPassword(getContextResources().getString(R.string.shared_pref_default_string),
-                DevicePolicyManager.RESET_PASSWORD_REQUIRE_ENTRY);
-        getDevicePolicyManager().lockNow();
-        getDevicePolicyManager().setPasswordQuality(getCdmDeviceAdmin(),
-                DevicePolicyManager.PASSWORD_QUALITY_UNSPECIFIED);
-        if (Constants.DEBUG_MODE_ENABLED) {
-            Log.d(TAG, "Password cleared");
+        try {
+            getDevicePolicyManager().setPasswordQuality(getCdmDeviceAdmin(),
+                    DevicePolicyManager.PASSWORD_QUALITY_UNSPECIFIED);
+            getDevicePolicyManager().setPasswordMinimumLength(getCdmDeviceAdmin(), getDefaultPasswordLength());
+            getDevicePolicyManager().resetPassword(getContextResources().getString(R.string.shared_pref_default_string),
+                    DevicePolicyManager.RESET_PASSWORD_REQUIRE_ENTRY);
+            getDevicePolicyManager().lockNow();
+            getDevicePolicyManager().setPasswordQuality(getCdmDeviceAdmin(),
+                    DevicePolicyManager.PASSWORD_QUALITY_UNSPECIFIED);
+            if (Constants.DEBUG_MODE_ENABLED) {
+                Log.d(TAG, "Password cleared");
+            }
+            operation.setStatus(getContextResources().getString(R.string.operation_value_completed));
+            getResultBuilder().build(operation);
+        } catch (SecurityException e) {
+            operation.setStatus(getContextResources().getString(R.string.operation_value_error));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                operation.setOperationResponse(getContextResources().getString(R.string.error_clear_passcode_nougat));
+            } else {
+                operation.setOperationResponse(getContextResources().getString(R.string.error_clear_passcode));
+            }
+            getResultBuilder().build(operation);
         }
     }
 

--- a/client/client/src/main/res/values/strings.xml
+++ b/client/client/src/main/res/values/strings.xml
@@ -229,6 +229,8 @@
     <string name="shared_pref_reboot_result">rebootResult</string>
 
     <!-- ERROR MESSAGES -->
+    <string name="error_clear_passcode_nougat">Passcode clearing is not supported in the BYOD enrollment for Android Nougat upwards</string>
+    <string name="error_clear_passcode">Passcode clearing is not supported by the device</string>
     <string name="error_connect_to_server">Could not connect to server please check your internet connection and try again</string>
     <string name="error_heading_connection">Connection Error</string>
     <string name="error_registration_failed">Registration Failed</string>


### PR DESCRIPTION
## Purpose
Issue related to Wifi compliance failing, ring operation not working and inability to stop the ring and minor other fixes

## Goals
https://github.com/wso2/cdmf-agent-android/commit/83cad5dc41ee154f4ab903b1b77fd7922ede57a7
The agent app include a logic to increase the ringtone volume of a device if its muted. However, when playing the ringtone, the stream used is not the ringtone stream, and it has used notification stream. If the notification volume is muted, the ring will not be heard.

https://github.com/wso2/cdmf-agent-android/commit/15035664792de071d3d7f172b5efbd2e87f97b5f
WiFi API of Android which is used to return the currently connected WiFi network seems to return, the SSID wrapped in extra double quotes and this causes the compliance check to fail always.

https://github.com/wso2/cdmf-agent-android/commit/473cd254ca67774a2eeb18d9d8ff9637cd9c4df7
Inability to close the ring operation stop dialog box due to the way that the  dialog box has been opened is fixed and the dialog box is now opened similar to the way it has been opened in similar places in the agent.

https://github.com/wso2/cdmf-agent-android/commit/de4fc4283bf8d47dcc15cb80c80c1248d7ae6f69
getDevicePolicyManager().resetPassword() method is no longer accessible to BYOD device which does not have device owner or profile owner in Android N upwards. This causes an infinite loop in the agent to close due to the exception thrown by calling the above method and the exception has been handled properly.

https://github.com/wso2/cdmf-agent-android/commit/808a37887de786cbf2f856f3f1d7a6a4c51a0974
Agent get into an infinite loop due due to the Work profile policy has not been revoked.

## Test environment
Android N
