### PR TITLE
Verifying package name before uninstalling an application

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/WorkProfileManager.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/WorkProfileManager.java
@@ -52,7 +52,11 @@ public class WorkProfileManager extends Activity {
                 activity.getApplicationContext().getPackageName());
         // Once the provisioning is done, user is prompted to uninstall the agent in personal profile.
         ApplicationManager applicationManager = new ApplicationManager(this.getApplicationContext());
-        applicationManager.uninstallApplication(Constants.PACKAGE_NAME, null);
+        try {
+            applicationManager.uninstallApplication(Constants.PACKAGE_NAME, null);
+        } catch (AndroidAgentException e) {
+            Log.e(TAG,"App uninstallation failed");
+        }
 
         if (intent.resolveActivity(activity.getPackageManager()) != null) {
             startActivityForResult(intent, REQUEST_PROVISION_MANAGED_PROFILE);

--- a/client/client/src/main/java/org/wso2/emm/agent/api/ApplicationManager.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/api/ApplicationManager.java
@@ -426,11 +426,16 @@ public class ApplicationManager {
      *
      * @param packageName - Application package name should be passed in as a String.
      */
-    public void uninstallApplication(String packageName, String schedule) {
+    public void uninstallApplication(String packageName, String schedule) throws AndroidAgentException {
         if (packageName != null &&
                 !packageName.contains(resources.getString(R.string.application_package_prefix))) {
             packageName = resources.getString(R.string.application_package_prefix) + packageName;
         }
+
+        if(!this.isPackageInstalled(packageName)){
+            throw new AndroidAgentException("Package is not installed in the device");
+        }
+
         if (schedule != null && !schedule.trim().isEmpty() && !schedule.equals("undefined")) {
             try {
                 AlarmUtils.setOneTimeAlarm(context, schedule, Constants.Operation.UNINSTALL_APPLICATION, null, null, packageName);

--- a/client/client/src/main/java/org/wso2/emm/agent/services/AlarmReceiver.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/AlarmReceiver.java
@@ -58,7 +58,11 @@ public class AlarmReceiver extends BroadcastReceiver {
 				applicationManager.installApp(appUrl, null, operation);
 			} else if(operationCode != null && operationCode.trim().equals(Constants.Operation.UNINSTALL_APPLICATION)) {
 				String packageUri = intent.getStringExtra(context.getResources().getString(R.string.app_uri));
-				applicationManager.uninstallApplication(packageUri, null);
+				try {
+					applicationManager.uninstallApplication(packageUri, null);
+				} catch (AndroidAgentException e) {
+					Log.e(TAG, "App uninstallation failed." + e);
+				}
 			}
 
 		} else {

--- a/client/client/src/main/java/org/wso2/emm/agent/services/ApplicationManagementService.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/ApplicationManagementService.java
@@ -130,7 +130,11 @@ public class ApplicationManagementService extends IntentService implements APIRe
                 break;
             case Constants.Operation.UNINSTALL_APPLICATION:
                 if (appUri != null) {
-                    applicationManager.uninstallApplication(appUri, null);
+                    try {
+                        applicationManager.uninstallApplication(appUri, null);
+                    } catch (AndroidAgentException e) {
+                        Log.e(TAG, "App uninstallation failed." + e);
+                    }
                 } else {
                     Toast.makeText(context, context.getResources().getString(R.string.toast_app_removal_failed),
                                    Toast.LENGTH_LONG).show();

--- a/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
@@ -218,6 +218,35 @@ public class MessageProcessor implements APIResultCallBack {
 						R.string.firmware_upgrade_response_message), null);
 			}
 
+			int applicationUninstallOperationId = Preference.getInt(context, context.getResources().getString(
+					R.string.app_uninstall_id));
+			String applicationUninstallOperationCode = Preference.getString(context, context.getResources().getString(
+					R.string.app_uninstall_code));
+			String applicationUninstallOperationStatus = Preference.getString(context, context.getResources().getString(
+					R.string.app_uninstall_status));
+			String applicationUninstallOperationMessage = Preference.getString(context, context.getResources().getString(
+					R.string.app_uninstall_failed_message));
+
+			if (applicationUninstallOperationStatus != null && applicationUninstallOperationId != 0 && applicationUninstallOperationCode != null) {
+				Operation applicationOperation = new Operation();
+				ApplicationManager appMgt = new ApplicationManager(context);
+				applicationOperation.setId(applicationUninstallOperationId);
+				applicationOperation.setCode(applicationUninstallOperationCode);
+				applicationOperation = appMgt.getApplicationInstallationStatus(
+						applicationOperation, applicationUninstallOperationStatus, applicationUninstallOperationMessage);
+				if (replyPayload == null) {
+					replyPayload = new ArrayList<>();
+				}
+				replyPayload.add(applicationOperation);
+
+				Preference.putString(context, context.getResources().getString(
+						R.string.app_install_status), null);
+				Preference.putString(context, context.getResources().getString(
+						R.string.app_install_failed_message), null);
+			}
+
+
+
 			int applicationOperationId = Preference.getInt(context, context.getResources().getString(
 					R.string.app_install_id));
 			String applicationOperationCode = Preference.getString(context, context.getResources().getString(

--- a/client/client/src/main/java/org/wso2/emm/agent/services/operation/OperationManager.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/operation/OperationManager.java
@@ -591,9 +591,12 @@ public abstract class OperationManager implements APIResultCallBack, VersionBase
                 if (appData.has(getContextResources().getString(R.string.app_schedule))) {
                     schedule = appData.getString(getContextResources().getString(R.string.app_schedule));
                 }
+                int operationId = operation.getId();
+                String operationCode = operation.getCode();
+                Preference.putInt(context, context.getResources().getString(R.string.app_uninstall_id), operationId);
+                Preference.putString(context, context.getResources().getString(R.string.app_uninstall_code), operationCode);
                 getAppList().uninstallApplication(packageName, schedule);
-                operation.setStatus(getContextResources().getString(R.string.operation_value_completed));
-                getResultBuilder().build(operation);
+
             }
 
             if (Constants.DEBUG_MODE_ENABLED) {

--- a/client/client/src/main/res/values/strings.xml
+++ b/client/client/src/main/res/values/strings.xml
@@ -373,9 +373,13 @@
     <string name="is_automatic_firmware_upgrade">isAutomaticFirmwareUpgrade</string>
     <string name="firmware_upgrade_automatic_retry">autoRetry</string>
     <string name="app_install_failed_message">appInstallFailedMessage</string>
+    <string name="app_uninstall_failed_message">appUnInstallFailedMessage</string>
     <string name="app_install_id">appInstallOperationId</string>
+    <string name="app_uninstall_id">appUninstallOperationId</string>
     <string name="app_install_code">appInstallOperationCode</string>
+    <string name="app_uninstall_code">appUninstallOperationCode</string>
     <string name="app_install_status">appInstallStatus</string>
+    <string name="app_uninstall_status">appUnInstallStatus</string>
     <string name="operation_receivedTimeStamp">receivedTimeStamp</string>
     <string name="operation_createdTimeStamp">createdTimeStamp</string>
     <string name="operation_payLoad">payLoad</string>


### PR DESCRIPTION
## Purpose
> In case of app uninstallation is called with invalid package name agent will checks and verify the given package name before uninstalling the application: Resolves https://github.com/wso2/product-iots/issues/1551
