### PR TITLE
Fix for https://github.com/wso2/product-iots/issues/1541

### DIFF
--- a/client/client/src/main/java/org/wso2/iot/agent/services/PolicyOperationsMapper.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/PolicyOperationsMapper.java
@@ -25,7 +25,7 @@ import org.wso2.iot.agent.utils.Constants;
 
 /**
  * This class is used to create specific operation with respect to
- * recieved policy payload.
+ * received policy payload.
  */
 public class PolicyOperationsMapper {
 

--- a/client/client/src/main/java/org/wso2/iot/agent/services/PolicyRevokeHandler.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/PolicyRevokeHandler.java
@@ -230,7 +230,7 @@ public class PolicyRevokeHandler {
                 List<String> systemAppList = Arrays.asList(enableSystemAppsData.split(resources.getString(
                         R.string.split_delimiter)));
                 for (String packageName : systemAppList) {
-                    hideSystemApp(packageName);
+                    setApplicationHidden(packageName, true);
                 }
             }
             if (!profileData.isNull(resources.getString(R.string.intent_extra_hide_system_apps))) {
@@ -239,7 +239,7 @@ public class PolicyRevokeHandler {
                 List<String> systemAppList = Arrays.asList(hideSystemAppsData.split(resources.getString(
                         R.string.split_delimiter)));
                 for (String packageName : systemAppList) {
-                    enableSystemApp(packageName);
+                    setApplicationHidden(packageName, false);
                 }
             }
             if (!profileData.isNull(resources.getString(R.string.intent_extra_unhide_system_apps))) {
@@ -248,7 +248,7 @@ public class PolicyRevokeHandler {
                 List<String> systemAppList = Arrays.asList(unhideSystemAppsData.split(resources.getString(
                         R.string.split_delimiter)));
                 for (String packageName : systemAppList) {
-                    hideSystemApp(packageName);
+                    setApplicationHidden(packageName, true);
                 }
             }
             if (!profileData.isNull(resources.getString(R.string.intent_extra_enable_google_play_apps))) {
@@ -274,17 +274,8 @@ public class PolicyRevokeHandler {
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private void enableSystemApp(String packageName) {
-        try {
-            devicePolicyManager.enableSystemApp(deviceAdmin, packageName);
-        } catch (IllegalArgumentException e) {
-            Log.e(TAG, "App is not available on the device to enable. " + e.toString());
-        }
-    }
-
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private void hideSystemApp(String packageName) {
-        devicePolicyManager.setApplicationHidden(deviceAdmin, packageName, true);
+    private void setApplicationHidden(String packageName, boolean isHidden) {
+        devicePolicyManager.setApplicationHidden(deviceAdmin, packageName, isHidden);
     }
 
     /**


### PR DESCRIPTION
## Purpose
> When a policy with work profile restrictions (In this case system apps that have to be enabled in the work profile) is enabled the android error shows "Invalid operation code received: work profile". This PR fixed that issue and implement missing policy revoke flow for Work Profile policy.
https://github.com/wso2/product-iots/issues/1541

## Goals
> Implement policy revoke flow for Work Profile policy and improve work profile policy enforcement.

## Approach
> Modify PolicyRevokeHandler class to restore previous work profile state when Work Profile policy is removed.

## User stories
> N/A, Bug fix

## Release note
> This PR will include necessary improvements and changes to apply Work Profile policy correctly and revoke it.

## Documentation
> N/A, Bug fix

## Training
> N/A, Bug fix

## Certification
> N/A, Bug fix

## Marketing
> N/A, Bug fix

## Automation tests
N/A, cannot cover with automations

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A, Bug fix

## Related PRs
> No

## Migrations (if applicable)
> Directly up-gradable from 3.1.26 release.

## Test environment
> Android 7.1.1 API 25, emulator
 
## Learning
> N/A, Bug fix