### PR TITLE
 Retrieve location using FusedLocationClient on devices which have Google Play Services

### DIFF
--- a/client/client/build.gradle
+++ b/client/client/build.gradle
@@ -750,6 +750,8 @@ dependencies {
     compile 'com.android.support:appcompat-v7:25.4.0'
     compile 'com.android.support:design:25.4.0'
     compile 'commons-io:commons-io:2.5'
+    compile 'com.google.android.gms:play-services-base:11.8.0'
+    compile "com.google.android.gms:play-services-location:11.8.0"
     compile 'com.google.firebase:firebase-core:11.8.0'
     compile 'com.google.firebase:firebase-messaging:11.8.0'
     compile 'com.fasterxml.jackson.core:jackson-core:2.6.4'

--- a/client/client/src/main/java/org/wso2/iot/agent/services/LocationUpdateReceiver.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/LocationUpdateReceiver.java
@@ -28,7 +28,7 @@ public class LocationUpdateReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (intent.hasExtra(Constants.Location.LOCATION)) {
-            location = (Location) intent.getExtra(Constants.Location.LOCATION);
+            location = intent.getParcelableExtra(Constants.Location.LOCATION);
         }
         if (location == null) {
             Log.w(TAG, "Location not received");

--- a/client/client/src/main/java/org/wso2/iot/agent/services/location/LocationService.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/location/LocationService.java
@@ -209,6 +209,7 @@ public class LocationService extends Service implements LocationListener {
             }
             if (mFusedLocationClient != null) {
                 mFusedLocationClient.removeLocationUpdates(mLocationCallback);
+                isUpdateRequested = false;
             }
         }
         if (Constants.DEBUG_MODE_ENABLED) {

--- a/client/client/src/main/java/org/wso2/iot/agent/services/location/LocationService.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/location/LocationService.java
@@ -19,7 +19,6 @@
 package org.wso2.iot.agent.services.location;
 
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.location.Location;
@@ -32,6 +31,17 @@ import android.os.IBinder;
 import android.provider.Settings;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationResult;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.LocationSettingsRequest;
+import com.google.android.gms.location.SettingsClient;
+import com.google.android.gms.tasks.OnSuccessListener;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -53,14 +63,29 @@ public class LocationService extends Service implements LocationListener {
 
     private static final String TAG = LocationService.class.getSimpleName();
 
+    private FusedLocationProviderClient mFusedLocationClient = null;
     private LocationManager locationManager = null;
-    private Context context;
     private static final long MIN_DISTANCE_CHANGE_FOR_UPDATES = 1; //If more than 1Km
     private static final long MIN_TIME_BW_UPDATES = 1000 * 5; //If more than 5 minutes
     private List<String> providers = new ArrayList<>();
     private boolean isUpdateRequested = false;
     private final IBinder mBinder = new LocalBinder();
     private long lastPublishedLocationTime;
+
+    private LocationCallback mLocationCallback = new LocationCallback() {
+        @Override
+        public void onLocationResult(LocationResult locationResult) {
+            Location location = null;
+            long locationTime = 0;
+            for (Location l : locationResult.getLocations()) {
+                if (l != null && l.getTime() > locationTime) {
+                    locationTime = l.getTime();
+                    location = l;
+                }
+            }
+            onLocationChanged(location);
+        }
+    };
 
     public class LocalBinder extends Binder {
         LocationService getService() {
@@ -77,13 +102,13 @@ public class LocationService extends Service implements LocationListener {
         if (Constants.ASK_TO_ENABLE_LOCATION) {
             if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 try {
-                    int locationSetting = Settings.Secure.getInt(context.getContentResolver(),
+                    int locationSetting = Settings.Secure.getInt(this.getContentResolver(),
                             Settings.Secure.LOCATION_MODE);
                     if (locationSetting == 0) {
-                        CommonUtils.displayNotification(context,
+                        CommonUtils.displayNotification(this,
                                 R.drawable.ic_warning_white_24dp,
-                                context.getResources().getString(R.string.title_need_location),
-                                context.getResources().getString(R.string.msg_need_location),
+                                this.getResources().getString(R.string.title_need_location),
+                                this.getResources().getString(R.string.msg_need_location),
                                 AlreadyRegisteredActivity.class,
                                 Constants.LOCATION_DISABLED,
                                 Constants.LOCATION_DISABLED_NOTIFICATION_ID);
@@ -97,28 +122,46 @@ public class LocationService extends Service implements LocationListener {
             }
         }
         if (Build.VERSION.SDK_INT >= 23
-                && ContextCompat.checkSelfPermission(context, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
-                && ContextCompat.checkSelfPermission(context, android.Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                && ContextCompat.checkSelfPermission(this,
+                android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
+                && ContextCompat.checkSelfPermission(this,
+                android.Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
             displayPermissionMissingNotification();
             return START_NOT_STICKY;
         }
-        Location location = null;
-        long locationTime = 0;
-        //We are trying for all enabled providers
-        List<String> _providers = locationManager.getProviders(true);
-        for (String p : _providers) {
-            Location l = locationManager.getLastKnownLocation(p);
-            if (l != null && l.getTime() > locationTime) {
-                locationTime = l.getTime();
-                location = l;
-            } else if (Constants.DEBUG_MODE_ENABLED) {
-                Log.d(TAG, "Last known location from provider " + p + " is not found or too old.");
+        if (locationManager == null && mFusedLocationClient != null) {
+            mFusedLocationClient.getLastLocation()
+                    .addOnSuccessListener(new OnSuccessListener<Location>() {
+                        @Override
+                        public void onSuccess(Location location) {
+                            // Got last known location. In some rare situations this can be null.
+                            if (location != null) {
+                                broadcastLocation(location);
+                            } else {
+                                Log.w(TAG, "No last known location found");
+                            }
+                        }
+                    });
+        } else if (locationManager != null && mFusedLocationClient == null) {
+            Location location = null;
+            long locationTime = 0;
+            //We are trying for all enabled providers
+            List<String> _providers = locationManager.getProviders(true);
+            for (String p : _providers) {
+                Location l = locationManager.getLastKnownLocation(p);
+                if (l != null && l.getTime() > locationTime) {
+                    locationTime = l.getTime();
+                    location = l;
+                } else if (Constants.DEBUG_MODE_ENABLED) {
+                    Log.d(TAG, "Last known location from provider " + p
+                            + " is not found or too old.");
+                }
             }
-        }
-        if (location != null) {
-            broadcastLocation(location);
-        } else {
-            Log.w(TAG, "No last known location found");
+            if (location != null) {
+                broadcastLocation(location);
+            } else {
+                Log.w(TAG, "No last known location found");
+            }
         }
         return START_STICKY;
     }
@@ -136,27 +179,36 @@ public class LocationService extends Service implements LocationListener {
         if (Constants.DEBUG_MODE_ENABLED) {
             Log.d(TAG, "Creating service");
         }
-        context = getApplicationContext();
-        if (locationManager == null) {
-            locationManager = (LocationManager) context.getSystemService(LOCATION_SERVICE);
+        if (isPlayServicesAvailable()) {
+            mFusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
+        } else {
+            Log.i(TAG, "Play services not available on this device. Using location manager");
+            locationManager = (LocationManager) getSystemService(LOCATION_SERVICE);
         }
-        setLocation();
+        requestLocationUpdates();
     }
 
     @Override
     public void onDestroy() {
-        if (locationManager != null && isUpdateRequested) {
+        if (isUpdateRequested) {
             if (Build.VERSION.SDK_INT >= 23
-                    && ContextCompat.checkSelfPermission(context, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
-                    && ContextCompat.checkSelfPermission(context, android.Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                    && ContextCompat.checkSelfPermission(this,
+                    android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
+                    && ContextCompat.checkSelfPermission(this,
+                    android.Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
                 displayPermissionMissingNotification();
                 return;
             }
-            try {
-                locationManager.removeUpdates(this);
-                isUpdateRequested = false;
-            } catch (Exception ex) {
-                Log.e(TAG, "fail to remove location listeners", ex);
+            if (locationManager != null) {
+                try {
+                    locationManager.removeUpdates(this);
+                    isUpdateRequested = false;
+                } catch (Exception ex) {
+                    Log.e(TAG, "fail to remove location listeners", ex);
+                }
+            }
+            if (mFusedLocationClient != null) {
+                mFusedLocationClient.removeLocationUpdates(mLocationCallback);
             }
         }
         if (Constants.DEBUG_MODE_ENABLED) {
@@ -167,15 +219,17 @@ public class LocationService extends Service implements LocationListener {
     /**
      * In this method, it gets the latest location updates from gps/ network.
      */
-    private void setLocation() {
+    private void requestLocationUpdates() {
+        if (Build.VERSION.SDK_INT >= 23
+                && ContextCompat.checkSelfPermission(this,
+                android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
+                && ContextCompat.checkSelfPermission(this,
+                android.Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            displayPermissionMissingNotification();
+            return;
+        }
         if (locationManager != null) {
             try {
-                if (Build.VERSION.SDK_INT >= 23
-                        && ContextCompat.checkSelfPermission(context, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
-                        && ContextCompat.checkSelfPermission(context, android.Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                    displayPermissionMissingNotification();
-                    return;
-                }
                 providers = locationManager.getProviders(true);
                 if (providers != null && !providers.isEmpty()) {
                     if (isUpdateRequested) {
@@ -195,8 +249,26 @@ public class LocationService extends Service implements LocationListener {
             } catch (RuntimeException e) {
                 Log.e(TAG, "No network or GPS Switched off.", e);
             }
+        } else if (mFusedLocationClient != null) {
+            LocationRequest mLocationRequest = new LocationRequest();
+            mLocationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+            mLocationRequest.setInterval(MIN_TIME_BW_UPDATES);
+
+            // Create LocationSettingsRequest object using location request
+            LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder();
+            builder.addLocationRequest(mLocationRequest);
+            LocationSettingsRequest locationSettingsRequest = builder.build();
+
+            // Check whether location settings are satisfied
+            // https://developers.google.com/android/reference/com/google/android/gms/location/SettingsClient
+            SettingsClient settingsClient = LocationServices.getSettingsClient(this);
+            settingsClient.checkLocationSettings(locationSettingsRequest);
+
+            mFusedLocationClient.requestLocationUpdates(mLocationRequest, mLocationCallback,
+                    null /* Looper */);
+            isUpdateRequested = true;
         } else {
-            Log.e(TAG, "Location manager is not available.");
+            Log.e(TAG, "Location manager or Fused Location Client is not available.");
             stopSelf();
         }
     }
@@ -210,7 +282,8 @@ public class LocationService extends Service implements LocationListener {
     public void onLocationChanged(Location location) {
         if (location != null) {
             if (Constants.DEBUG_MODE_ENABLED) {
-                Log.d(TAG, "Location changed> lat:" + location.getLatitude() + " lon:" + location.getLongitude() + " provider:" + location.getProvider());
+                Log.d(TAG, "Location changed> lat:" + location.getLatitude()
+                        + " lon:" + location.getLongitude() + " provider:" + location.getProvider());
             }
             broadcastLocation(location);
         }
@@ -228,7 +301,7 @@ public class LocationService extends Service implements LocationListener {
         if (Constants.DEBUG_MODE_ENABLED) {
             Log.d(TAG, "Provider enabled: " + provider);
         }
-        setLocation();
+        requestLocationUpdates();
     }
 
     @Override
@@ -236,8 +309,8 @@ public class LocationService extends Service implements LocationListener {
         if (Constants.DEBUG_MODE_ENABLED) {
             Log.d(TAG, "Provider disabled: " + provider);
         }
-        if (providers.contains(provider) && locationManager != null) {
-            setLocation();
+        if (providers.contains(provider)) {
+            requestLocationUpdates();
         }
     }
 
@@ -255,7 +328,7 @@ public class LocationService extends Service implements LocationListener {
             EventPayload eventPayload = new EventPayload();
             eventPayload.setPayload(locationPayload);
             eventPayload.setType(Constants.EventListeners.LOCATION_EVENT_TYPE);
-            HttpDataPublisher httpDataPublisher = new HttpDataPublisher(context);
+            HttpDataPublisher httpDataPublisher = new HttpDataPublisher(this);
             httpDataPublisher.publish(eventPayload);
             lastPublishedLocationTime = location.getTime();
             if (Constants.DEBUG_MODE_ENABLED) {
@@ -285,19 +358,29 @@ public class LocationService extends Service implements LocationListener {
                 locationObject.put(Constants.LocationInfo.TIME_STAMP, new Date().getTime());
                 locationString = locationObject.toString();
             } catch (JSONException e) {
-                Log.e(TAG, "Error occurred while creating a location payload for location event publishing", e);
+                Log.e(TAG, "Error occurred while creating a location payload for location " +
+                        "event publishing", e);
             }
         }
         return locationString;
     }
 
     private void displayPermissionMissingNotification() {
-        CommonUtils.displayNotification(context,
+        CommonUtils.displayNotification(this,
                 R.drawable.ic_warning_white_24dp,
-                context.getResources().getString(R.string.title_need_permissions),
-                context.getResources().getString(R.string.msg_need_permissions),
+                this.getResources().getString(R.string.title_need_permissions),
+                this.getResources().getString(R.string.msg_need_permissions),
                 AlreadyRegisteredActivity.class,
                 Constants.PERMISSION_MISSING,
                 Constants.PERMISSION_MISSING_NOTIFICATION_ID);
+    }
+
+    /**
+     * Check the device to make sure it has the Google Play Services.
+     */
+    private boolean isPlayServicesAvailable() {
+        GoogleApiAvailability apiAvailability = GoogleApiAvailability.getInstance();
+        int resultCode = apiAvailability.isGooglePlayServicesAvailable(this);
+        return (resultCode == ConnectionResult.SUCCESS);
     }
 }


### PR DESCRIPTION
## Purpose
> In some android devices, location updates are only notified to location manager if location fetched via GPS. Passive location sources and network based location retrieval is not possible on those devices with native location manager in Android. However it is possible to retrieve passive & network based location via Fused Location Client provided with Google Play services. However it is not possible to use Fused Location Client on devices which don't have Google Play services. 

## Goals
> Retrieve device location via Fused Location Client, if device has Google Play services. Otherwise get location via native Location Manager.

## Approach
> Check the existence of Play Services on the device and use Fused Location Client, if Play Services available. Otherwise use Native Location Manager to retrieve location updates.

## User stories
> N/A, Internal functionality

## Release note
- Improved location retrieval on devices which use Google play services by using Fused Location Client.

## Documentation
> N/A, Internal functionality

## Training
> N/A, Internal functionality

## Certification
> N/A, Internal functionality

## Marketing
> N/A, Internal functionality

## Automation tests
> N/A, Cannot automate the functionality

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> > N/A, Internal functionality

## Related PRs
> No

## Migrations (if applicable)
> Directly up-gradable from 3.1.27

## Test environment
> Android 7.0 (API 24) without Google APIs, Android 7.1 (API 25) with Google APIs
 
## Learning
> > N/A, Internal functionality