### PR TITLE
fixing https://github.com/wso2/product-iots/issues/1614

### DIFF
--- a/client/client/src/main/AndroidManifest.xml
+++ b/client/client/src/main/AndroidManifest.xml
@@ -43,6 +43,7 @@
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
     <uses-permission android:name="org.wso2.iot.system.service.permission.ACCESS" />
     <uses-permission android:name="org.wso2.iot.agent.permission.ACCESS" />
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="18" />

--- a/client/client/src/main/java/org/wso2/iot/agent/activities/AlreadyRegisteredActivity.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/activities/AlreadyRegisteredActivity.java
@@ -206,6 +206,20 @@ public class AlreadyRegisteredActivity extends AppCompatActivity implements APIR
 				missingPermissions.add(android.Manifest.permission.WRITE_EXTERNAL_STORAGE);
 			}
 
+            NotificationManager notificationManager = (NotificationManager) context
+                    .getSystemService(Context.NOTIFICATION_SERVICE);
+            // This is to handle permission obtaining for Android N devices where operations such
+            // as mute that can cause a device to go into "do not disturb" will need additional
+            // permission. Added here as well to support already enrolled devices to optain the
+            // permission without reenrolling.
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M && !notificationManager
+                    .isNotificationPolicyAccessGranted()) {
+                CommonDialogUtils.getAlertDialogWithOneButtonAndTitle(context,
+                        getResources().getString(R.string.dialog_do_not_distrub_title),
+                        getResources().getString(R.string.dialog_do_not_distrub_message),
+                        getResources().getString(R.string.ok), doNotDisturbClickListener);
+            }
+
 			if (missingPermissions.isEmpty()) {
 				NotificationManager mNotificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 				mNotificationManager.cancel(Constants.PERMISSION_MISSING, Constants.PERMISSION_MISSING_NOTIFICATION_ID);
@@ -270,6 +284,17 @@ public class AlreadyRegisteredActivity extends AppCompatActivity implements APIR
 			loadInitialActivity();
 		}
 	}
+
+    private DialogInterface.OnClickListener doNotDisturbClickListener = new DialogInterface
+            .OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            Intent intent = new Intent(
+                    android.provider.Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS);
+            startActivityForResult(intent, Constants.DO_NOT_DISTURB_REQUEST_CODE);
+            dialog.dismiss();
+        }
+    };
 
 	@Override
 	protected void onDestroy(){

--- a/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
@@ -186,6 +186,7 @@ public class Constants {
 	public static final int APP_LIST_REQUEST_CODE = 313;
 	public static final int DYNAMIC_CLIENT_UNREGISTER_REQUEST_CODE = 314;
 	public static final int SCEP_REQUEST_CODE = 300;
+	public static final int DO_NOT_DISTURB_REQUEST_CODE = 315;
 	/**
 	 * Tag used on log messages.
 	 */

--- a/client/client/src/main/res/values/strings.xml
+++ b/client/client/src/main/res/values/strings.xml
@@ -283,6 +283,10 @@
     <string name="dialog_system_app_required">Please install the WSO2 System App to continue enrollment as a COPE user.</string>
     <string name="dialog_tenants_not_available">You do not have any associated organizations. Please contact your administrator</string>
     <string name="dialog_select_tenant">Select an Organization to register your device with.</string>
+    <string name="dialog_do_not_distrub_title">Permission for do not disturb mode change</string>
+    <string name="dialog_do_not_distrub_message">Some operations such as mute, requires agent
+        application to be able to control do not disturb mode, please enable it from
+        the next screen. After ticking, please press back and return to the agent</string>
 
     <!-- REGISTRATION -->
     <string name="register_button_text">Register</string>


### PR DESCRIPTION
## Purpose
The mute operation makes Android N devices stop accepting any more commands.
fixing https://github.com/wso2/product-iots/issues/1614

## Goals
Add the new permission required to mute device.

## Approach
Added the permission necessery to gain access to do not disturb mode

## User stories
N/A

## Release note
Fixing the mute operation not working for Android N devices.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
Covered with existing code

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
Migration for old to new devices is considered and it is handled by the code automatically.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.