### PR TITLE
 Fix for wso2/product-iots#1641

### DIFF
--- a/client/client/build.gradle
+++ b/client/client/build.gradle
@@ -36,8 +36,8 @@ android {
         targetSdkVersion 25
         multiDexEnabled true
 
-        versionCode 3010029
-        versionName "3.1.29"
+        versionCode 3010030
+        versionName "3.1.30"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/client/client/src/main/java/org/wso2/iot/agent/services/MessageProcessor.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/MessageProcessor.java
@@ -508,7 +508,7 @@ public class MessageProcessor implements APIResultCallBack {
                     }
                 } else if (Constants.Status.AUTHENTICATION_FAILED.equals(responseStatus) &&
                         org.wso2.iot.agent.proxy.utils.Constants.REFRESH_TOKEN_EXPIRED.equals(response)) {
-                    Log.d(TAG, "Requesting credentials to obtain new token pair.");
+                    Log.i(TAG, "Requesting credentials to obtain new token pair.");
                     LocalNotification.stopPolling(context);
                     Preference.putBoolean(context, Constants.TOKEN_EXPIRED, true);
                     CommonUtils.displayNotification(context,

--- a/client/iDPProxy/src/main/java/org/wso2/iot/agent/proxy/APIController.java
+++ b/client/iDPProxy/src/main/java/org/wso2/iot/agent/proxy/APIController.java
@@ -52,7 +52,7 @@ import java.util.Map;
  * return API results to the client.
  */
 public class APIController implements TokenCallBack {
-	private static final String TAG = "APIController";
+	private static final String TAG = APIController.class.getSimpleName();
 	private Token token;
 	private String clientKey, clientSecret;
 	private APIResultCallBack apiResultCallback;

--- a/client/iDPProxy/src/main/java/org/wso2/iot/agent/proxy/AccessTokenHandler.java
+++ b/client/iDPProxy/src/main/java/org/wso2/iot/agent/proxy/AccessTokenHandler.java
@@ -182,7 +182,7 @@ public class AccessTokenHandler {
                     timeToExpireSecond = Long.parseLong(response.getString(Constants.EXPIRE_LABEL));
                     Token token = new Token();
                     long expiresOn = new Date().getTime()
-                            + (timeToExpireSecond - Constants.HttpClient.TOKEN_VALIDITY_PERCENTAGE * timeToExpireSecond / 100) * 1000;
+                            + (timeToExpireSecond - (100 - Constants.HttpClient.TOKEN_VALIDITY_PERCENTAGE) * timeToExpireSecond / 100) * 1000;
                     token.setExpiresOn(new Date(expiresOn));
                     token.setRefreshToken(refreshToken);
                     token.setAccessToken(accessToken);

--- a/client/iDPProxy/src/main/java/org/wso2/iot/agent/proxy/IdentityProxy.java
+++ b/client/iDPProxy/src/main/java/org/wso2/iot/agent/proxy/IdentityProxy.java
@@ -83,10 +83,14 @@ public class IdentityProxy implements CallBack {
 
     @Override
     public void receiveNewAccessToken(String status, String message, Token token) {
-        if (Constants.DEBUG_ENABLED && token != null) {
-            Log.d(TAG, "Using Access Token: " + token.getAccessToken());
+        if (token != null) {
+            if (Constants.DEBUG_ENABLED) {
+                Log.d(TAG, "Using Access Token: " + token.getAccessToken());
+            }
+            IdentityProxy.token = token;
+        } else {
+            Log.w(TAG, "Token is not renewed. Status: " + status);
         }
-        IdentityProxy.token = token;
         tokenCallBack.onReceiveTokenResult(token, status, message);
     }
 

--- a/client/iDPProxy/src/main/java/org/wso2/iot/agent/proxy/utils/Constants.java
+++ b/client/iDPProxy/src/main/java/org/wso2/iot/agent/proxy/utils/Constants.java
@@ -98,6 +98,7 @@ public class Constants {
 	public final static String CLIENT_SECRET = "client_secret";
 	public final static String TOKEN_ENDPOINT = "token_endpoint";
 	public static enum HTTP_METHODS{GET, POST, DELETE, PUT};
+	public static final String CLIENT_ERROR = "-1";
 	public static final String INTERNAL_SERVER_ERROR = "500";
 	public static final String ACCESS_FAILURE = "400";
 	public static final String REQUEST_SUCCESSFUL = "200";


### PR DESCRIPTION
## Purpose
> Fix wso2/product-iots#1641

## Goals
> Agent needs to prompt authentication failure notification when agent is unable to renew the token.

## Approach
> Show notification to re authenticate if refresh token expired.

## User stories
> N/A

## Release note
> Improved agent to show a notification to re authenticate if refresh token expired.

## Documentation
> N/A, this is intuitive action taken by the agent

## Training
> N/A

## Certification
> N/A, this is intuitive action taken by the agent

## Marketing
> N/A, this is intuitive action taken by the agent

## Automation tests
> Unable to automate

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> No

## Related PRs
> No

## Migrations (if applicable)
> Up gradable from 3.1.29

## Test environment
> Android 7.1.1 API 25 x86 Emulator
 
## Learning
> N/A, this is intuitive action taken by the agent