### PR TITLE
Fixes the issue of app download stuck in IN_PROGRESS state

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/api/ApplicationManager.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/api/ApplicationManager.java
@@ -338,6 +338,13 @@ public class ApplicationManager {
             operationCode = Preference.getString(context, context.getResources().getString(
                     R.string.app_install_code));
 
+            if(operationId == 0){
+                Preference.putInt(context, context.getResources().getString(
+                        R.string.app_install_id), operation.getId());
+                Log.d(TAG, "Currently executing - operation Id " + Preference.getInt(context,
+                        context.getResources().getString(R.string.app_install_id)));
+                }
+
             if (operationId == operation.getId()) {
                 Log.w(TAG, "Ignoring received operation as it has the same operation ID with ongoing operation.");
                 return; //No point of putting same operation again to the pending queue. Hence ignoring.
@@ -348,20 +355,11 @@ public class ApplicationManager {
                 appInstallRequest.setApplicationOperationId(operation.getId());
                 appInstallRequest.setApplicationOperationCode(operation.getCode());
                 appInstallRequest.setAppUrl(url);
+                Log.d(TAG, "Queued operation Id " + appInstallRequest.getApplicationOperationId());
                 AppInstallRequestUtil.addPending(context, appInstallRequest);
                 Log.d(TAG, "Added request to pending queue as there is another installation ongoing.");
                 if (!downloadOngoing) {
                     // Probably installation might ongoing
-                    int attempt = Preference.getInt(context, APP_INSTALLATION_ATTEMPT);
-                    if (attempt >= 1) {
-                        Preference.putInt(context, APP_INSTALLATION_ATTEMPT, 0);
-                        Preference.putInt(context, context.getResources().getString(
-                                R.string.app_install_id), 0);
-                        Preference.putString(context, context.getResources().getString(
-                                R.string.app_install_code), null);
-                    } else {
-                        Preference.putInt(context, APP_INSTALLATION_ATTEMPT, ++attempt);
-                    }
                 } else {
                     downloadOngoing = false; //Let's check whether it is actually ongoing or not.
                 }
@@ -383,10 +381,8 @@ public class ApplicationManager {
      * @param operationCode - Requested operation code.
      */
     public void setupAppDownload(String url, int operationId, String operationCode) {
-        Preference.putInt(context, context.getResources().getString(
-                R.string.app_install_id), operationId);
-        Preference.putString(context, context.getResources().getString(
-                R.string.app_install_code), operationCode);
+        Log.d(TAG, "Setting up app download for the operation Id " + Preference.getInt(context,
+                context.getResources().getString(R.string.app_install_id)));
 
         if (url.contains(Constants.APP_DOWNLOAD_ENDPOINT) && Constants.APP_MANAGER_HOST != null) {
             url = url.substring(url.lastIndexOf("/"), url.length());

--- a/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
@@ -328,7 +328,8 @@ public class MessageProcessor implements APIResultCallBack {
 			Operation applicationOperation = new Operation();
 			applicationOperation.setId(appInstallRequest.getApplicationOperationId());
 			applicationOperation.setCode(appInstallRequest.getApplicationOperationCode());
-			Log.d(TAG, "Try to start app installation from queue.");
+            Log.d(TAG, "Try to start app installation from queue. Operation Id " +
+                    appInstallRequest.getApplicationOperationId());
 			applicationManager.installApp(appInstallRequest.getAppUrl(), null, applicationOperation);
 		}
 	}


### PR DESCRIPTION
## Purpose
> This PR will fix the issue of app download stuck in IN_PROGRESS state. Further explaining, every time we trigger two or more enterprise INSTALL_APPLICATION operations in a row, the first operation does not come to a COMPLETED state even the app get installed successfully. For an example if we put three INSTALL_APPLICATION operations in a row, the first operation will be in IN_PROGRESS state while other two get updated to COMPLETED state.  Resolves https://github.com/wso2/product-iots/issues/1656

## Goals
> After this fix if we put two or more INSTALL_APPLICATION operations in a row, all the operations will get updated to COMPLETED state.

## Approach
> Change the the place where shared preference _app_install_id_'s value is set on the installApp method and remove the app installation attempt check.  

## User stories
> Assume that a user has pushed more than two Android applications in a row using app store to a particular device. Now he wants to know whether all the application installed successful or what the status of his/her action.  

## Release note
> Fixes the issue of app download stuck in IN_PROGRESS state

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A