### PR TITLE
Fix the issue of app download stuck in IN_PROGRESS state

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/api/ApplicationManager.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/api/ApplicationManager.java
@@ -383,6 +383,8 @@ public class ApplicationManager {
     public void setupAppDownload(String url, int operationId, String operationCode) {
         Log.d(TAG, "Setting up app download for the operation Id " + Preference.getInt(context,
                 context.getResources().getString(R.string.app_install_id)));
+        Preference.putString(context, context.getResources().getString(
+                                R.string.app_install_code), operationCode);
 
         if (url.contains(Constants.APP_DOWNLOAD_ENDPOINT) && Constants.APP_MANAGER_HOST != null) {
             url = url.substring(url.lastIndexOf("/"), url.length());


### PR DESCRIPTION
## Purpose
> This will fix the issue of app installation operations stuck in IN_PROGRESS status even though the application get installed on the device

## Goals
> With this fix even though we put single or more INSTALL_APPLICATION operations in a row, all the operations will get updated to COMPLETED state.

## User stories
> A user wants to see an  application installed status, whether it is successful or failed.

## Documentation
> N/A

## Certification
> N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A