### PR TITLE
Fixed the issue with app uninstallation failure 

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/api/ApplicationManager.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/api/ApplicationManager.java
@@ -250,6 +250,7 @@ public class ApplicationManager {
 
     public boolean isPackageInstalled(String packagename) {
         try {
+            packagename = packagename.replace("package:", "");
             PackageInfo packageInfo = packageManager.
                     getPackageInfo(packagename, PackageManager.GET_ACTIVITIES);
             if (packageInfo != null) {


### PR DESCRIPTION
## Purpose
> This will fix the issue of Android agent is returning the status "ERROR" with the message 'Package is not installed in the device or invalid package name' even though app is installed on the device. Resolves wso2/product-iots#1673

## Goals
> This will enable enterprise silent app uninstallation on an enrolled device.

## Approach
> The package name was incorrectly sent to the isPackageInstalled() method.

## User stories
> Application is installed on the device. Schedule app uninstallation operation to the device. Verify the response from IoT Server. 
IoT server should return the status as "COMPLETED" if the uninstallation was triggered on an app that was installed in the device.

## Documentation
> N/A

## Certification
> N/A

## Marketing
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> N/A
 