### PR TITLE
Fix for https://github.com/wso2/product-iots/issues/1679

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
@@ -243,6 +243,14 @@ public class MessageProcessor implements APIResultCallBack {
 						R.string.app_uninstall_status), null);
 				Preference.putString(context, context.getResources().getString(
 						R.string.app_uninstall_failed_message), null);
+
+				if (context.getResources().getString(R.string.operation_value_error).equals(applicationOperation.getStatus()) ||
+						context.getResources().getString(R.string.operation_value_completed).equals(applicationOperation.getStatus())){
+					Preference.putInt(context, context.getResources().getString(
+							R.string.app_uninstall_id), 0);
+					Preference.putString(context, context.getResources().getString(
+							R.string.app_uninstall_code), null);
+				}
 			}
 
 			int applicationOperationId = Preference.getInt(context, context.getResources().getString(


### PR DESCRIPTION
## Purpose
> When an application uninstallation operations are placed once, once it completes or failed, operation status keep on updating.: Resolves wso2/product-iots#1679

## Goals
> Prevent app uninstallation operation status being sent continuously

## Approach
> Maintain app uninstallation states correctly though the app uninstallation life cycle.

## User stories
> N/A, Bug fix

## Release note
> Fixed wso2/product-iots#1679

## Documentation
> N/A, Bug fix

## Training
> N/A, Bug fix

## Certification
> N/A, Bug fix

## Marketing
> N/A, Bug fix

## Automation tests
Cannot automate

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A, Bug fix

## Related PRs
> No

## Migrations (if applicable)
> N/A

## Test environment
> Android API 23
 
## Learning
> N/A, Bug fix