### PR TITLE
Fix for OTA resumable download continuing even after download window has expired. 

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
@@ -73,6 +73,7 @@ public class MessageProcessor implements APIResultCallBack {
 	private DevicePolicyManager devicePolicyManager;
 	private static final int ACTIVATION_REQUEST = 47;
 	private static final String ERROR_STATE = "ERROR";
+	private static final String COMPLETE_STATE = "COMPLETED";
 	private String shellCommand = null;
 
 	/**
@@ -158,6 +159,7 @@ public class MessageProcessor implements APIResultCallBack {
 		String requestParams;
 		ObjectMapper mapper = new ObjectMapper();
         int applicationOperationId = 0;
+		int firmwareUpgradeOperationId = 0;
 		try {
 			requestParams =  mapper.writeValueAsString(replyPayload);
 			if (replyPayload != null) {
@@ -168,10 +170,22 @@ public class MessageProcessor implements APIResultCallBack {
 					} else if (operation.getCode().equals(Constants.Operation.REBOOT) && !operation.getStatus().
 							equals(ERROR_STATE)) {
 						isRebootTriggered = true;
-					} else if (operation.getCode().equals(Constants.Operation.UPGRADE_FIRMWARE) && !operation.getStatus().
-							equals(ERROR_STATE)) {
-						isUpgradeTriggered = true;
+					} else if (operation.getCode().equals(Constants.Operation.UPGRADE_FIRMWARE)) {
+						if(!operation.getStatus().equals(COMPLETE_STATE) && !operation.getStatus().equals(ERROR_STATE))
+						Log.i(TAG, "operation status at the moment is " + operation.getStatus());
+						//Initially when the operation status is In Progress, 'isUpgradeTriggered'
+						// is set to 'true' to call the system app. After initial call, to prevent
+						// calling system app again and again for the same operation Id following
+						// check is added.
+						int opId = Preference.getInt(context, "firmwareOperationId");
+						if(opId == operation.getId()){
+							isUpgradeTriggered = false;
+						} else {
+							isUpgradeTriggered = true;
+						}
 						Preference.putInt(context, "firmwareOperationId", operation.getId());
+						//Operation Id of the received replypayload is stored
+						firmwareUpgradeOperationId = operation.getId();
 					} else if (operation.getCode().equals(Constants.Operation.EXECUTE_SHELL_COMMAND) && !operation.getStatus().
 							equals(ERROR_STATE)) {
 						isShellCommandTriggered = true;
@@ -186,7 +200,11 @@ public class MessageProcessor implements APIResultCallBack {
 			}
 			int firmwareOperationId = Preference.getInt(context, context.getResources().getString(
 					R.string.firmware_upgrade_response_id));
+
 			if (firmwareOperationId != 0) {
+				//If there's a firmwareResponseId that means the operation is already triggered.
+				// Therefore cleaning the operation Id set above
+				firmwareUpgradeOperationId = 0;
 				org.wso2.emm.agent.beans.Operation firmwareOperation = new org.wso2.emm.agent.beans.Operation();
 				firmwareOperation.setId(firmwareOperationId);
 				firmwareOperation.setCode(Constants.Operation.UPGRADE_FIRMWARE);
@@ -194,6 +212,10 @@ public class MessageProcessor implements APIResultCallBack {
 						R.string.firmware_upgrade_response_status)));
 				boolean isRetryPending = Preference.getBoolean(context, context.getResources().
 						getString(R.string.firmware_upgrade_retry_pending));
+				if ("ERROR".equals(Preference.getString(context, context.getResources().getString(
+						R.string.firmware_upgrade_response_status)))) {
+					isUpgradeTriggered = false;
+				}
 				if (isRetryPending) {
                     isUpgradeTriggered = true;
 					int retryCount = Preference.getInt(context, context.getResources().
@@ -218,6 +240,11 @@ public class MessageProcessor implements APIResultCallBack {
 						R.string.operation_value_error));
 				Preference.putString(context, context.getResources().getString(
 						R.string.firmware_upgrade_response_message), null);
+			}
+
+			//if there's no new firmware upgrade operation this will prevent calling system app
+			if (firmwareUpgradeOperationId == 0){
+				isUpgradeTriggered = false;
 			}
 
 			int applicationUninstallOperationId = Preference.getInt(context, context.getResources().getString(

--- a/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
@@ -158,7 +158,7 @@ public class MessageProcessor implements APIResultCallBack {
 
 		String requestParams;
 		ObjectMapper mapper = new ObjectMapper();
-        int applicationOperationId = 0;
+		int applicationOperationId = 0;
 		int firmwareUpgradeOperationId = 0;
 		try {
 			requestParams =  mapper.writeValueAsString(replyPayload);
@@ -212,12 +212,12 @@ public class MessageProcessor implements APIResultCallBack {
 						R.string.firmware_upgrade_response_status)));
 				boolean isRetryPending = Preference.getBoolean(context, context.getResources().
 						getString(R.string.firmware_upgrade_retry_pending));
-				if ("ERROR".equals(Preference.getString(context, context.getResources().getString(
+				if (ERROR_STATE.equals(Preference.getString(context, context.getResources().getString(
 						R.string.firmware_upgrade_response_status)))) {
 					isUpgradeTriggered = false;
 				}
 				if (isRetryPending) {
-                    isUpgradeTriggered = true;
+					isUpgradeTriggered = true;
 					int retryCount = Preference.getInt(context, context.getResources().
 							getString(R.string.firmware_upgrade_retries));
 					firmwareOperation.setOperationResponse("Attempt " + retryCount +

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/api/OTAServerManager.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/api/OTAServerManager.java
@@ -537,8 +537,10 @@ public class OTAServerManager {
                                     serverManager.stateChangeListener.onStateOrProgress(OTAStateChangeListener.STATE_IN_DOWNLOADING,
                                             OTAStateChangeListener.ERROR_PACKAGE_INSTALL_FAILED, null, DEFAULT_STATE_INFO_CODE);
                                 }
+                                downloading = false;
+                                downloadReference = 0L;
                                 cursor.close();
-                                break;
+                                return;
                             }
 
                             int bytesDownloaded = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR));


### PR DESCRIPTION
## Purpose
> After a total timeout(even thought the resumable download window has expired) of firmware upgrade operation OTA starts again from 0% until status is completed. Upgrade status was successful always. Status has to be Error when the time frame is expired. Resolves https://github.com/wso2/product-iots/issues/1692.

## Goals
> Identified the second operation call for the same operation id and filter it to eliminate passing the firmware upgrade operation again to the system app. 

## Approach
> Android agent's Message processor will listen to the second time system app call for the same operation and eliminate it.

## User stories
> Send an OTA of Android OS to a device and device's network get disconnected while download is ongoing. Network failure stays until resumable download window expires. Once the networks reconnected on the download continues.  Expected behavior is to operation status should be marked as  ERROR. 

## Release note
> wso2/product-iots/issues/1692

## Documentation
> N/A. Bug fix.

## Training
> N/A. Bug fix.

## Certification
> N/A. Bug fix.

## Marketing
> N/A. Bug fix.

## Automation tests
 Cannot automate

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A. Bug fix.

## Related PRs
> N/A. Bug fix.

## Migrations (if applicable)
> 2.1.0 Android Agent can be updated directly

## Test environment
Android API 23
 
## Learning
> N/A. Bug fix.
