### PR TITLE
Fixed https://github.com/wso2/product-iots/issues/1695

### DIFF
--- a/client/client/build.gradle
+++ b/client/client/build.gradle
@@ -36,8 +36,8 @@ android {
         targetSdkVersion 25
         multiDexEnabled true
 
-        versionCode 3010030
-        versionName "3.1.30"
+        versionCode 3010031
+        versionName "3.1.31"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/client/client/src/main/java/org/wso2/iot/agent/api/ApplicationManager.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/api/ApplicationManager.java
@@ -318,7 +318,9 @@ public class ApplicationManager {
         if(Constants.DEFAULT_OWNERSHIP == Constants.OWNERSHIP_COSU){
             installPackage(fileUri);
         }else{
-
+            boolean isUnknownSourcesDisallowed = Preference.getBoolean(context,
+                    Constants.PreferenceFlag.DISALLOW_UNKNOWN_SOURCES);
+            CommonUtils.allowUnknownSourcesForProfile(context, !isUnknownSourcesDisallowed);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 Intent intent = new Intent(Intent.ACTION_INSTALL_PACKAGE);
                 intent.setDataAndType(fileUri, resources.getString(R.string.application_mgr_mime));

--- a/client/client/src/main/java/org/wso2/iot/agent/services/PolicyRevokeHandler.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/PolicyRevokeHandler.java
@@ -187,6 +187,13 @@ public class PolicyRevokeHandler {
                 case Constants.Operation.DISALLOW_DEBUGGING_FEATURES:
                 case Constants.Operation.DISALLOW_INSTALL_APPS:
                 case Constants.Operation.DISALLOW_INSTALL_UNKNOWN_SOURCES:
+                    boolean isUnknownSourcesDisallowed = Preference.getBoolean(context,
+                            Constants.PreferenceFlag.DISALLOW_UNKNOWN_SOURCES);
+                    if (isUnknownSourcesDisallowed) {
+                        Preference.putBoolean(context,
+                                Constants.PreferenceFlag.DISALLOW_UNKNOWN_SOURCES, false);
+                        CommonUtils.allowUnknownSourcesForProfile(context, true);
+                    }
                 case Constants.Operation.DISALLOW_MODIFY_ACCOUNTS:
                 case Constants.Operation.DISALLOW_OUTGOING_BEAM:
                 case Constants.Operation.DISALLOW_SHARE_LOCATION:

--- a/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManagerWorkProfile.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManagerWorkProfile.java
@@ -349,6 +349,11 @@ public class OperationManagerWorkProfile extends OperationManager {
         String key = operation.getCode();
         operation.setStatus(getContextResources().getString(R.string.operation_value_completed));
         getResultBuilder().build(operation);
+        if (Constants.Operation.DISALLOW_INSTALL_UNKNOWN_SOURCES.equals(key)) {
+            Preference.putBoolean(getContext(),
+                    Constants.PreferenceFlag.DISALLOW_UNKNOWN_SOURCES, isEnable);
+            CommonUtils.allowUnknownSourcesForProfile(getContext(), !isEnable);
+        }
         if (isEnable) {
             getDevicePolicyManager().addUserRestriction(getCdmDeviceAdmin(), getPermissionConstantValue(key));
             if (Constants.DEBUG_MODE_ENABLED) {

--- a/client/client/src/main/java/org/wso2/iot/agent/utils/CommonUtils.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/utils/CommonUtils.java
@@ -32,6 +32,8 @@ import android.content.res.Resources;
 import android.location.Location;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.Build;
+import android.provider.Settings;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.TaskStackBuilder;
 import android.util.Base64;
@@ -729,6 +731,20 @@ public class CommonUtils {
 	private static int getTimeDistanceInMinutes(long time) {
 		long timeDistance = currentDate().getTime() - time;
 		return Math.round((Math.abs(timeDistance) / 1000) / 60);
+	}
+
+	public static void allowUnknownSourcesForProfile(final Context context, final boolean isEnabled) {
+		if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+			final DevicePolicyManager manager = (DevicePolicyManager) context
+					.getSystemService(Context.DEVICE_POLICY_SERVICE);
+			if (manager != null && manager.isProfileOwnerApp(context.getApplicationContext()
+					.getPackageName())) {
+				final ComponentName cdmAdmin = new ComponentName(context, AgentDeviceAdminReceiver.class);
+				manager.setSecureSetting(cdmAdmin, Settings.Secure.INSTALL_NON_MARKET_APPS,
+						isEnabled ? "1" : "0");
+				Log.i(TAG, "Enable unknown sources: " + String.valueOf(isEnabled));
+			}
+		}
 	}
 
 }

--- a/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
@@ -573,6 +573,7 @@ public class Constants {
 		public static final String DEVICE_ID_PREFERENCE_KEY = "deviceId";
 		public static final String LAST_SERVER_CALL = "lastServerCall";
 		public static final String DEVICE_INITIALIZED = "false";
+		public static final String DISALLOW_UNKNOWN_SOURCES = "DISALLOW_UNKNOWN_SOURCES";
 
 		private PreferenceFlag() {
 			throw new AssertionError();

--- a/client/gradle/wrapper/gradle-wrapper.properties
+++ b/client/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip


### PR DESCRIPTION
## Purpose
> Fix issue in install or update app in work profile via app manager.

## Goals
> Allow user to install / update apps from app manager if policy permits to install apps from unknown sources.

## Approach
> Configure unknown sources Secure Setting via device policy manager if current policy permits to install apps from unknown sources.

## User stories
> N/A, bug fix

## Release note
> Fixed https://github.com/wso2/product-iots/issues/1695

## Documentation
> N/A, Bug fix

## Training
> N/A, Bug fix

## Certification
> N/A, Bug fix

## Marketing
> N/A, Bug fix

## Automation tests
> Cannot automate

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A, Bug fix

## Related PRs
> No

## Migrations (if applicable)
> Up-gradable from Agent 3.1.30

## Test environment
> Android API 25 7.1.1
 
## Learning
> N/A, Bug fix