### PR TITLE
Compile for SDK 27 and rework gradle scripts

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -26,13 +26,9 @@ buildscript {
 
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.google.gms:google-services:3.1.0'
     }
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.2.3'
 }
 
 allprojects {

--- a/client/client/build.gradle
+++ b/client/client/build.gradle
@@ -28,17 +28,91 @@ repositories {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
     defaultConfig {
         applicationId "org.wso2.iot.agent"
         minSdkVersion 17
-        targetSdkVersion 25
+        targetSdkVersion 27
         multiDexEnabled true
 
         versionCode 3010031
         versionName "3.1.31"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        // FIRMWARE_UPGRADE_RETRY_COUNT: How many time the agent must retry if firmware upgrade
+        // fails.
+        buildConfigField("int", "FIRMWARE_UPGRADE_RETRY_COUNT", "0")
+        // ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE: Setting this to true will make the
+        // App list response to the service to include system apps as well.
+        buildConfigField("boolean", "ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE", "false")
+        // HIDE_UNREGISTER_BUTTON: Hide the unregister button after enrollment so that  the
+        // unenrollment can only be done remotely.
+        buildConfigField("boolean", "HIDE_UNREGISTER_BUTTON", "false")
+        // COSU related configurations.
+        // ALLOW_MULTIPLE_APPS_IN_COSU_MODE: Set to true to make all installed app in COSU mode
+        // accessible; if false only the last installation will be accessible.
+        buildConfigField("boolean", "ALLOW_MULTIPLE_APPS_IN_COSU_MODE", "true")
+        // By enabling this button, data wipe can be performed on a device without having to
+        // issue a remote wipe operation.
+        buildConfigField("boolean", "DISPLAY_WIPE_DEVICE_BUTTON", "true")
+        buildConfigField("String", "EULA_TITLE", "\"POLICY AGREEMENT\"")
+
+        // Build and flavor independent configurations
+        //API version that supported by the server
+        buildConfigField("float", "SERVER_API_VERSION", "1.0f")
+        //Minimum Server API version that supported by the agent app
+        buildConfigField("float", "MIN_SERVER_API_VERSION", "1.0f")
+        //Maximum Server API version that supported by the agent app
+        buildConfigField("float", "MAX_SERVER_API_VERSION", "1.0f")
+        // AGENT_PACKAGE: If a modification of the agent's package name is done, this must be
+        // altered
+        buildConfigField("String", "AGENT_PACKAGE", "\"org.wso2.iot.agent\"")
+        // CATALOG_APP_PACKAGE_NAME: If a modification of the catalog apps's package
+        // name is done, this must be altered.
+        buildConfigField("String", "CATALOG_APP_PACKAGE_NAME", "\"org.wso2.app.catalog\"")
+        // SYSTEM_SERVICE_PACKAGE: If system service app is in use, the package name of it is
+        // defined here so that the agent knows the package name of the system service to
+        // contact.
+        buildConfigField("String", "SYSTEM_SERVICE_PACKAGE", "\"org.wso2.iot.system.service\"")
+
+        //Data publishing related configurations.
+        // LOG_PUBLISHER_IN_USE: By default DAS_PUBLISHER or SPLUNK_PUBLISHER are the allowed
+        // values. This specifies the log publisher to be used. This can be extended to write
+        // custom publishers.
+        buildConfigField("String", "LOG_PUBLISHER_IN_USE", "\"<SET_PUBLISHER>\"")
+        // LOG_LEVEL: When publishing log cat output to server, the log level tobe used.
+        buildConfigField("String", "LOG_LEVEL", "\"*:W\"")
+        // NUMBER_OF_LOG_LINES: Number of log lines to be sent.
+        buildConfigField("int", "NUMBER_OF_LOG_LINES", "500")
+        //Splunk related configurations
+        buildConfigField("String", "SPLUNK_API_KEY", "\"<SET_PUBLISHER>\"")
+        // HEC_TOKEN: Allowed values are MINT or HTTP
+        buildConfigField("String", "SPLUNK_DATA_COLLECTOR_TYPE", "\"MINT\"")
+        buildConfigField("String", "HEC_TOKEN", "\"<SPLUNK_HEC_TOKEN>\"")
+        buildConfigField("String", "HEC_MINT_ENDPOINT_URL", "\"<SPLUNK_HEC_MINT_ENDPOINT_URL>\"")
+        //Event publishing related configurations.
+        // If set to true, registered events will be published to DAS. There are two event
+        // publisher available by default and custom event types can be written and published
+        // with the provided extension points.
+        buildConfigField("boolean", "EVENT_LISTENING_ENABLED", "false")
+        // Listening to application state changes such as an app getting installed, uninstalled,
+        // upgraded and data cleared. If set to true, events will be published.
+        buildConfigField("boolean", "APPLICATION_STATE_LISTENER", "false")
+        // This is to listen to Runtime information such as CPU. If set to true,
+        // events will be published.
+        buildConfigField("boolean", "RUNTIME_STATE_LISTENER", "false")
+        // The time the alarm should first go off, in milliseconds.
+        buildConfigField("int", "DEFAULT_START_TIME", "10000")
+        // The interval between subsequent repeats of the alarm, in milliseconds.
+        buildConfigField("int", "DEFAULT_INTERVAL", "300000")
+        // The interval between subsequent repeats of the alarm, in milliseconds under FCM.
+        // The default value is 600000.
+        buildConfigField("int", "DEFAULT_FCM_INTERVAL", "600000")
+        // Enable background pull notifications strategy in order to fallback from FCM
+        // when there a FCM outage.
+        buildConfigField("boolean", "FCM_FALLBACK_PULL_ENABLED", "true")
+        buildConfigField("int", "DEFAULT_LISTENER_CODE", "10001")
     }
 
     buildTypes {
@@ -46,652 +120,175 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
             applicationVariants.all { variant ->
-                variant.outputs.each { output ->
-                    output.outputFile = new File(output.outputFile.parent, output.outputFile.name.replace("client-release-unsigned.apk", "android-agent" + ".apk"))
+                variant.outputs.all {
+                    outputFileName = "android-agent-${variant.name}-${variant.versionName}.apk"
                 }
             }
             // DEBUG_MODE_ENABLED: Make the agent print the debug logs.
-            buildConfigField "boolean", "DEBUG_MODE_ENABLED", "false"
-            // ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE: Setting this to true will make the
-            // App list response to the service to include system apps as well.
-            buildConfigField "boolean", "ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE", "false"
-            // Protocol used to communicate with the server. Valid values are http:// or https://
-            buildConfigField "String", "SERVER_PROTOCOL", "\"https://\""
-            buildConfigField "String", "API_SERVER_PORT", "\"443\""
-            //API version that supported by the server
-            buildConfigField "float", "SERVER_API_VERSION", "1.0f"
-            // Set DEFAULT_OWNERSHIP to null if no overriding is needed. Other possible values are,
-            // BYOD or COPE. If you are using the mutual SSL authentication
-            // This value must be set to a value other than null.
-            buildConfigField "String", "DEFAULT_OWNERSHIP", "\"BYOD\""
-            //DEFAULT_HOST - Hardcode the server host to avoid having the user type it during
-            //enrollment. If the user must type the hostname/IP during enrollment, leave it as null.
-            buildConfigField "String", "DEFAULT_HOST", "\"https://gateway.api.cloud.wso2.com\""
-            // APP_MANAGER_HOST: If the App store host is different from the DEFAULT_HOST
-            // change this value.
-            buildConfigField "String", "APP_MANAGER_HOST", "null"
-            // CLOUD_MANAGER: If the App is pointed to cloud use cloud management host to resolve
-            // tenants of user. Otherwise set this to null
-            buildConfigField "String", "CLOUD_MANAGER", "\"https://cloudmgt.cloud.wso2.com/cloudmgt\""
-            // SIGN_UP_URL: Set self registration link to sign up
-            buildConfigField "String", "SIGN_UP_URL", "\"http://wso2.com/iot/cloud/\""
-            // AGENT_PACKAGE: If a modification of the agent's package name is done, this must be
-            // altered
-            buildConfigField "String", "AGENT_PACKAGE", "\"org.wso2.iot.agent\""
-            // FIRMWARE_UPGRADE_RETRY_COUNT: How many time the agent must retry if firmware upgrade
-            // fails.
-            buildConfigField "int", "FIRMWARE_UPGRADE_RETRY_COUNT", "0"
-            // CATALOG_APP_PACKAGE_NAME: If a modification of the catalog apps's package
-            // name is done, this must be altered.
-            buildConfigField "String", "CATALOG_APP_PACKAGE_NAME", "\"org.wso2.app.catalog\""
-            // System service specific configurations.
-            // SYSTEM_APP_ENABLED: This is to set if the system app will also be installed.
-            // If this is set org.wso2.iot.system.service must also be available in the device.
-            buildConfigField "boolean", "SYSTEM_APP_ENABLED", "false"
-            // SYSTEM_SERVICE_PACKAGE: If system service app is in use, the package name of it is
-            // defined here so that the agent knows the package name of the system service to
-            // contact.
-            buildConfigField "String", "SYSTEM_SERVICE_PACKAGE", "\"org.wso2.iot.system.service\""
-            // HIDE_UNREGISTER_BUTTON: Hide the unregister button after enrollment so that  the
-            // unenrollment can only be done remotely.
-            buildConfigField "boolean", "HIDE_UNREGISTER_BUTTON", "false"
-            // Auto enrollment specific configurations
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED: This is to specify if the enrollment
-            // will be done in a background service. This is typically related to mutual SSL based
-            // enrollments only.
-            buildConfigField "boolean", "AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED", "false"
-            // SKIP_LICENSE: Skip displaying the license policy during enrollment.
-            // This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "SKIP_LICENSE", "false"
-            // HIDE_LOGIN_UI: Skip displaying the login screen during enrollment.
-            // This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "HIDE_LOGIN_UI", "false"
-            // SKIP_WORK_PROFILE_CREATION: This will hide the work profile creation step from the
-            // user. This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "SKIP_WORK_PROFILE_CREATION", "true"
-            // HIDE_ERROR_DIALOG: If this is set to true, agent will not show any error messages.
-            // This is only recommended to use when the enrollment happens in background, and no
-            // user interaction is needed. i.e in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "HIDE_ERROR_DIALOG", "false"
-            //Data publishing related configurations.
-            // LOG_PUBLISHER_IN_USE: By default DAS_PUBLISHER or SPLUNK_PUBLISHER are the allowed
-            // values. This specifies the log publisher to be used. This can be extended to write
-            // custom publishers.
-            buildConfigField "String", "LOG_PUBLISHER_IN_USE", "\"<SET_PUBLISHER>\""
-            // LOG_LEVEL: When publishing log cat output to server, the log level tobe used.
-            buildConfigField "String", "LOG_LEVEL", "\"*:W\""
-            // NUMBER_OF_LOG_LINES: Number of log lines to be sent.
-            buildConfigField "int", "NUMBER_OF_LOG_LINES", "500"
-            //Splunk related configurations
-            buildConfigField "String", "SPLUNK_API_KEY", "\"<SET_PUBLISHER>\""
-            // HEC_TOKEN: Allowed values are MINT or HTTP
-            buildConfigField "String", "SPLUNK_DATA_COLLECTOR_TYPE", "\"MINT\""
-            buildConfigField "String", "HEC_TOKEN", "\"<SPLUNK_HEC_TOKEN>\""
-            buildConfigField "String", "HEC_MINT_ENDPOINT_URL", "\"<SPLUNK_HEC_MINT_ENDPOINT_URL>\""
-            //Event publishing related configurations.
-            // If set to true, registered events will be published to DAS. There are two event
-            // publisher available by default and custom event types can be written and published
-            // with the provided extension points.
-            buildConfigField "boolean", "EVENT_LISTENING_ENABLED", "false"
-            // Listening to application state changes such as an app getting installed, uninstalled,
-            // upgraded and data cleared. If set to true, events will be published.
-            buildConfigField "boolean", "APPLICATION_STATE_LISTENER", "false"
-            // This is to listen to Runtime information such as CPU. If set to true,
-            // events will be published.
-            buildConfigField "boolean", "RUNTIME_STATE_LISTENER", "false"
-            // The time the alarm should first go off, in milliseconds.
-            buildConfigField "int", "DEFAULT_START_TIME", "10000"
-            // The interval between subsequent repeats of the alarm, in milliseconds.
-            buildConfigField "int", "DEFAULT_INTERVAL", "300000"
-            // The interval between subsequent repeats of the alarm, in milliseconds under FCM.
-            // The default value is 600000.
-            buildConfigField "int", "DEFAULT_FCM_INTERVAL", "600000"
-            // Enable background pull notifications strategy in order to fallback from FCM
-            // when there a FCM outage.
-            buildConfigField "boolean", "FCM_FALLBACK_PULL_ENABLED", "true"
-            buildConfigField "int", "DEFAULT_LISTENER_CODE", "10001"
-            // COSU related configurations.
-            // ALLOW_MULTIPLE_APPS_IN_COSU_MODE: Set to true to make all installed app in COSU mode
-            // accessible; if false only the last installation will be accessible.
-            buildConfigField "boolean", "ALLOW_MULTIPLE_APPS_IN_COSU_MODE", "false"
-            // By enabling this button, data wipe can be performed on a device without having to
-            // issue a remote wipe operation.
-            buildConfigField "boolean", "DISPLAY_WIPE_DEVICE_BUTTON", "true"
+            buildConfigField("boolean", "DEBUG_MODE_ENABLED", "false")
             // Under COSU mode, this will enable an area in the screen to exit from screen pinned
             // mode. This MUST be set to false in production, if COSU is used.
-            buildConfigField "boolean", "COSU_SECRET_EXIT", "true"
-            buildConfigField "String", "EULA_TITLE", "\"POLICY AGREEMENT\""
-            //Minimum Server API version that supported by the agent app
-            buildConfigField "float", "MIN_SERVER_API_VERSION", "1.0f"
-            //Maximum Server API version that supported by the agent app
-            buildConfigField "float", "MAX_SERVER_API_VERSION", "1.0f"
-            //Show notification to enable location if it is disabled
-            buildConfigField "boolean", "ASK_TO_ENABLE_LOCATION", "false"
-            //Publish location changes to server
-            buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "false"
-            //Collect WiFi scan results
-            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
-        }
-        staging {
-            // DEBUG_MODE_ENABLED: Make the agent print the debug logs.
-            buildConfigField "boolean", "DEBUG_MODE_ENABLED", "true"
-            // ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE: Setting this to true will make the
-            // App list response to the service to include system apps as well.
-            buildConfigField "boolean", "ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE", "false"
-            // Protocol used to communicate with the server. Valid values are http:// or https://
-            buildConfigField "String", "SERVER_PROTOCOL", "\"https://\""
-            buildConfigField "String", "API_SERVER_PORT", "\"8243\""
-            //API version that supported by the server
-            buildConfigField "float", "SERVER_API_VERSION", "1.0f"
-            // Set DEFAULT_OWNERSHIP to null if no overriding is needed. Other possible values are,
-            // BYOD or COPE. If you are using the mutual SSL authentication
-            // This value must be set to a value other than null.
-            buildConfigField "String", "DEFAULT_OWNERSHIP", "\"BYOD\""
-            //DEFAULT_HOST - Hardcode the server host to avoid having the user type it during
-            //enrollment. If the user must type the hostname/IP during enrollment, leave it as null.
-            buildConfigField "String", "DEFAULT_HOST", "\"https://gateway.api.cloudstaging.wso2.com\""
-            // APP_MANAGER_HOST: If the App store host is different from the DEFAULT_HOST
-            // change this value.
-            buildConfigField "String", "APP_MANAGER_HOST", "null"
-            // CLOUD_MANAGER: If the App is pointed to cloud use cloud management host to resolve
-            // tenants of user. Otherwise set this to null
-            buildConfigField "String", "CLOUD_MANAGER", "\"https://cloudmgt.cloudstaging.wso2.com/cloudmgt\""
-            // SIGN_UP_URL: Set self registration link to sign up
-            buildConfigField "String", "SIGN_UP_URL", "\"http://wso2.com/iot/cloud/\""
-            // AGENT_PACKAGE: If a modification of the agent's package name is done, this must be
-            // altered
-            buildConfigField "String", "AGENT_PACKAGE", "\"org.wso2.iot.agent\""
-            // FIRMWARE_UPGRADE_RETRY_COUNT: How many time the agent must retry if firmware upgrade
-            // fails.
-            buildConfigField "int", "FIRMWARE_UPGRADE_RETRY_COUNT", "0"
-            // CATALOG_APP_PACKAGE_NAME: If a modification of the catalog apps's package
-            // name is done, this must be altered.
-            buildConfigField "String", "CATALOG_APP_PACKAGE_NAME", "\"org.wso2.app.catalog\""
-            // System service specific configurations.
-            // SYSTEM_APP_ENABLED: This is to set if the system app will also be installed.
-            // If this is set org.wso2.iot.system.service must also be available in the device.
-            buildConfigField "boolean", "SYSTEM_APP_ENABLED", "false"
-            // SYSTEM_SERVICE_PACKAGE: If system service app is in use, the package name of it is
-            // defined here so that the agent knows the package name of the system service to
-            // contact.
-            buildConfigField "String", "SYSTEM_SERVICE_PACKAGE", "\"org.wso2.iot.system.service\""
-            // HIDE_UNREGISTER_BUTTON: Hide the unregister button after enrollment so that  the
-            // unenrollment can only be done remotely.
-            buildConfigField "boolean", "HIDE_UNREGISTER_BUTTON", "false"
-            // Auto enrollment specific configurations
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED: This is to specify if the enrollment
-            // will be done in a background service. This is typically related to mutual SSL based
-            // enrollments only.
-            buildConfigField "boolean", "AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED", "false"
-            // SKIP_LICENSE: Skip displaying the license policy during enrollment.
-            // This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "SKIP_LICENSE", "false"
-            // HIDE_LOGIN_UI: Skip displaying the login screen during enrollment.
-            // This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "HIDE_LOGIN_UI", "false"
-            // SKIP_WORK_PROFILE_CREATION: This will hide the work profile creation step from the
-            // user. This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "SKIP_WORK_PROFILE_CREATION", "true"
-            // HIDE_ERROR_DIALOG: If this is set to true, agent will not show any error messages.
-            // This is only recommended to use when the enrollment happens in background, and no
-            // user interaction is needed. i.e in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "HIDE_ERROR_DIALOG", "false"
-            //Data publishing related configurations.
-            // LOG_PUBLISHER_IN_USE: By default DAS_PUBLISHER or SPLUNK_PUBLISHER are the allowed
-            // values. This specifies the log publisher to be used. This can be extended to write
-            // custom publishers.
-            buildConfigField "String", "LOG_PUBLISHER_IN_USE", "\"<SET_PUBLISHER>\""
-            // LOG_LEVEL: When publishing log cat output to server, the log level tobe used.
-            buildConfigField "String", "LOG_LEVEL", "\"*:W\""
-            // NUMBER_OF_LOG_LINES: Number of log lines to be sent.
-            buildConfigField "int", "NUMBER_OF_LOG_LINES", "500"
-            //Splunk related configurations
-            buildConfigField "String", "SPLUNK_API_KEY", "\"<SET_PUBLISHER>\""
-            // HEC_TOKEN: Allowed values are MINT or HTTP
-            buildConfigField "String", "SPLUNK_DATA_COLLECTOR_TYPE", "\"MINT\""
-            buildConfigField "String", "HEC_TOKEN", "\"<SPLUNK_HEC_TOKEN>\""
-            buildConfigField "String", "HEC_MINT_ENDPOINT_URL", "\"<SPLUNK_HEC_MINT_ENDPOINT_URL>\""
-            //Event publishing related configurations.
-            // If set to true, registered events will be published to DAS. There are two event
-            // publisher available by default and custom event types can be written and published
-            // with the provided extension points.
-            buildConfigField "boolean", "EVENT_LISTENING_ENABLED", "false"
-            // Listening to application state changes such as an app getting installed, uninstalled,
-            // upgraded and data cleared. If set to true, events will be published.
-            buildConfigField "boolean", "APPLICATION_STATE_LISTENER", "false"
-            // This is to listen to Runtime information such as CPU. If set to true,
-            // events will be published.
-            buildConfigField "boolean", "RUNTIME_STATE_LISTENER", "false"
-            // The time the alarm should first go off, in milliseconds.
-            buildConfigField "int", "DEFAULT_START_TIME", "10000"
-            // The interval between subsequent repeats of the alarm, in milliseconds.
-            buildConfigField "int", "DEFAULT_INTERVAL", "300000"
-            // The interval between subsequent repeats of the alarm, in milliseconds under FCM.
-            // The default value is 600000.
-            buildConfigField "int", "DEFAULT_FCM_INTERVAL", "600000"
-            // Enable background pull notifications strategy in order to fallback from FCM
-            // when there a FCM outage.
-            buildConfigField "boolean", "FCM_FALLBACK_PULL_ENABLED", "true"
-            buildConfigField "int", "DEFAULT_LISTENER_CODE", "10001"
-            // COSU related configurations.
-            // ALLOW_MULTIPLE_APPS_IN_COSU_MODE: Set to true to make all installed app in COSU mode
-            // accessible; if false only the last installation will be accessible.
-            buildConfigField "boolean", "ALLOW_MULTIPLE_APPS_IN_COSU_MODE", "false"
-            // By enabling this button, data wipe can be performed on a device without having to
-            // issue a remote wipe operation.
-            buildConfigField "boolean", "DISPLAY_WIPE_DEVICE_BUTTON", "true"
-            // Under COSU mode, this will enable an area in the screen to exit from screen pinned
-            // mode. This MUST be set to false in production, if COSU is used.
-            buildConfigField "boolean", "COSU_SECRET_EXIT", "true"
-            buildConfigField "String", "EULA_TITLE", "\"POLICY AGREEMENT\""
-            //Minimum Server API version that supported by the agent app
-            buildConfigField "float", "MIN_SERVER_API_VERSION", "1.0f"
-            //Maximum Server API version that supported by the agent app
-            buildConfigField "float", "MAX_SERVER_API_VERSION", "1.0f"
-            //Show notification to enable location if it is disabled
-            buildConfigField "boolean", "ASK_TO_ENABLE_LOCATION", "false"
-            //Publish location changes to server
-            buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "false"
-            //Collect WiFi scan results
-            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
-            debuggable true
-        }
-        debugCope {
-            // DEBUG_MODE_ENABLED: Make the agent print the debug logs.
-            // Make this false in production.
-            buildConfigField "boolean", "DEBUG_MODE_ENABLED", "true"
-            // ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE: Setting this to true will make the
-            // App list response to the service to include system apps as well.
-            buildConfigField "boolean", "ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE", "false"
-            // Protocol used to communicate with the server. Valid values are http:// or https://
-            buildConfigField "String", "SERVER_PROTOCOL", "\"http://\""
-            buildConfigField "String", "API_SERVER_PORT", "\"80\""
-            //API version that supported by the server
-            buildConfigField "float", "SERVER_API_VERSION", "1.0f"
-            // Set DEFAULT_OWNERSHIP to null if no overriding is needed. Other possible values are,
-            // BYOD or COPE. If you are using the mutual SSL authentication
-            // This value must be set to a value other than null.
-            buildConfigField "String", "DEFAULT_OWNERSHIP", "\"COPE\""
-            //DEFAULT_HOST - Hardcode the server host to avoid having the user type it during
-            //enrollment. If the user must type the hostname/IP during enrollment, leave it as null.
-            buildConfigField "String", "DEFAULT_HOST", "null"
-            // APP_MANAGER_HOST: If the App store host is different from the DEFAULT_HOST
-            // change this value.
-            buildConfigField "String", "APP_MANAGER_HOST", "null"
-            // CLOUD_MANAGER: If the App is pointed to cloud use cloud management host to resolve
-            // tenants of user. Otherwise set this to null
-            buildConfigField "String", "CLOUD_MANAGER", "null"
-            // SIGN_UP_URL: Set self registration link to sign up
-            buildConfigField "String", "SIGN_UP_URL", "null"
-            // AGENT_PACKAGE: If a modification of the agent's package name is done, this must be
-            // altered
-            buildConfigField "String", "AGENT_PACKAGE", "\"org.wso2.iot.agent\""
-            // FIRMWARE_UPGRADE_RETRY_COUNT: How many time the agent must retry if firmware upgrade
-            // fails.
-            buildConfigField "int", "FIRMWARE_UPGRADE_RETRY_COUNT", "0"
-            // CATALOG_APP_PACKAGE_NAME: If a modification of the catalog apps's package
-            // name is done, this must be altered.
-            buildConfigField "String", "CATALOG_APP_PACKAGE_NAME", "\"org.wso2.app.catalog\""
-            // System service specific configurations.
-            // SYSTEM_APP_ENABLED: This is to set if the system app will also be installed.
-            // If this is set org.wso2.iot.system.service must also be available in the device.
-            buildConfigField "boolean", "SYSTEM_APP_ENABLED", "true"
-            // SYSTEM_SERVICE_PACKAGE: If system service app is in use, the package name of it is
-            // defined here so that the agent knows the package name of the system service to
-            // contact.
-            buildConfigField "String", "SYSTEM_SERVICE_PACKAGE", "\"org.wso2.iot.system.service\""
-            // HIDE_UNREGISTER_BUTTON: Hide the unregister button after enrollment so that  the
-            // unenrollment can only be done remotely.
-            buildConfigField "boolean", "HIDE_UNREGISTER_BUTTON", "false"
-            // Auto enrollment specific configurations
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED: This is to specify if the enrollment
-            // will be done in a background service. This is typically related to mutual SSL based
-            // enrollments only.
-            buildConfigField "boolean", "AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED", "false"
-            // SKIP_LICENSE: Skip displaying the license policy during enrollment.
-            // This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "SKIP_LICENSE", "true"
-            // HIDE_LOGIN_UI: Skip displaying the login screen during enrollment.
-            // This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "HIDE_LOGIN_UI", "false"
-            // SKIP_WORK_PROFILE_CREATION: This will hide the work profile creation step from the
-            // user. This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "SKIP_WORK_PROFILE_CREATION", "true"
-            // HIDE_ERROR_DIALOG: If this is set to true, agent will not show any error messages.
-            // This is only recommended to use when the enrollment happens in background, and no
-            // user interaction is needed. i.e in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "HIDE_ERROR_DIALOG", "false"
-            //Data publishing related configurations.
-            // LOG_PUBLISHER_IN_USE: By default DAS_PUBLISHER or SPLUNK_PUBLISHER are the allowed
-            // values. This specifies the log publisher to be used. This can be extended to write
-            // custom publishers.
-            buildConfigField "String", "LOG_PUBLISHER_IN_USE", "\"<SET_PUBLISHER>\""
-            // LOG_LEVEL: When publishing log cat output to server, the log level tobe used.
-            buildConfigField "String", "LOG_LEVEL", "\"*:W\""
-            // NUMBER_OF_LOG_LINES: Number of log lines to be sent.
-            buildConfigField "int", "NUMBER_OF_LOG_LINES", "500"
-            //Splunk related configurations
-            buildConfigField "String", "SPLUNK_API_KEY", "\"<SET_PUBLISHER>\""
-            // HEC_TOKEN: Allowed values are MINT or HTTP
-            buildConfigField "String", "SPLUNK_DATA_COLLECTOR_TYPE", "\"MINT\""
-            buildConfigField "String", "HEC_TOKEN", "\"<SPLUNK_HEC_TOKEN>\""
-            buildConfigField "String", "HEC_MINT_ENDPOINT_URL", "\"<SPLUNK_HEC_MINT_ENDPOINT_URL>\""
-            //Event publishing related configurations.
-            // If set to true, registered events will be published to DAS. There are two event
-            // publisher available by default and custom event types can be written and publihed
-            // with the provided extension points.
-            buildConfigField "boolean", "EVENT_LISTENING_ENABLED", "false"
-            // Listening to application state changes such as an app getting installed, uninstalled,
-            // upgraded and data cleared. If set to true, events will be published.
-            buildConfigField "boolean", "APPLICATION_STATE_LISTENER", "false"
-            // This is to listen to Runtime information such as CPU. If set to true,
-            // events will be published.
-            buildConfigField "boolean", "RUNTIME_STATE_LISTENER", "false"
-            // The time the alarm should first go off, in milliseconds. The default value is 1000.
-            buildConfigField "int", "DEFAULT_START_TIME", "10000"
-            // The interval between subsequent repeats of the alarm, in milliseconds.
-            // The default value is 30000.
-            buildConfigField "int", "DEFAULT_INTERVAL", "60000"
-            // The interval between subsequent repeats of the alarm, in milliseconds under FCM.
-            // The default value is 600000.
-            buildConfigField "int", "DEFAULT_FCM_INTERVAL", "600000"
-            // Enable background pull notifications strategy in order to fallback from FCM
-            // when there a FCM outage.
-            buildConfigField "boolean", "FCM_FALLBACK_PULL_ENABLED", "true"
-            buildConfigField "int", "DEFAULT_LISTENER_CODE", "10001"
-            // COSU related configurations.
-            // ALLOW_MULTIPLE_APPS_IN_COSU_MODE: Set to true to make all installed app in COSU mode
-            // accessible; if false only the last installation will be accessible.
-            buildConfigField "boolean", "ALLOW_MULTIPLE_APPS_IN_COSU_MODE", "true"
-            // By enabling this button, data wipe can be performed on a device without having to
-            // issue a remote wipe operation.
-            buildConfigField "boolean", "DISPLAY_WIPE_DEVICE_BUTTON", "true"
-            // Under COSU mode, this will enable an area in the screen to exit from screen pinned
-            // mode. This MUST be set to false in production, if COSU is used.
-            buildConfigField "boolean", "COSU_SECRET_EXIT", "false"
-            buildConfigField "String", "EULA_TITLE", "\"POLICY AGREEMENT\""
-            //Minimum Server API version that supported by the agent app
-            buildConfigField "float", "MIN_SERVER_API_VERSION", "1.0f"
-            //Maximum Server API version that supported by the agent app
-            buildConfigField "float", "MAX_SERVER_API_VERSION", "1.0f"
-            //Show notification to enable location if it is disabled
-            buildConfigField "boolean", "ASK_TO_ENABLE_LOCATION", "false"
-            //Publish location changes to server
-            buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "false"
-            //Collect WiFi scan results
-            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "true"
-            debuggable true
-            signingConfig signingConfigs.debug
-        }
-        standalone {
-            // DEBUG_MODE_ENABLED: Make the agent print the debug logs.
-            // Make this false in production.
-            buildConfigField "boolean", "DEBUG_MODE_ENABLED", "false"
-            // ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE: Setting this to true will make the
-            // App list response to the service to include system apps as well.
-            buildConfigField "boolean", "ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE", "false"
-            // Protocol used to communicate with the server. Valid values are http:// or https://
-            buildConfigField "String", "SERVER_PROTOCOL", "\"http://\""
-            buildConfigField "String", "API_SERVER_PORT", "\"80\""
-            //API version that supported by the server
-            buildConfigField "float", "SERVER_API_VERSION", "1.0f"
-            // Set DEFAULT_OWNERSHIP to null if no overriding is needed. Other possible values are,
-            // BYOD or COPE. If you are using the mutual SSL authentication
-            // This value must be set to a value other than null.
-            buildConfigField "String", "DEFAULT_OWNERSHIP", "\"BYOD\""
-            //DEFAULT_HOST - Hardcode the server host to avoid having the user type it during
-            //enrollment. If the user must type the hostname/IP during enrollment, leave it as null.
-            buildConfigField "String", "DEFAULT_HOST", "null"
-            // APP_MANAGER_HOST: If the App store host is different from the DEFAULT_HOST
-            // change this value.
-            buildConfigField "String", "APP_MANAGER_HOST", "null"
-            // CLOUD_MANAGER: If the App is pointed to cloud use cloud management host to resolve
-            // tenants of user. Otherwise set this to null
-            buildConfigField "String", "CLOUD_MANAGER", "null"
-            // SIGN_UP_URL: Set self registration link to sign up
-            buildConfigField "String", "SIGN_UP_URL", "null"
-            // AGENT_PACKAGE: If a modification of the agent's package name is done, this must be
-            // altered
-            buildConfigField "String", "AGENT_PACKAGE", "\"org.wso2.iot.agent\""
-            // FIRMWARE_UPGRADE_RETRY_COUNT: How many time the agent must retry if firmware upgrade
-            // fails.
-            buildConfigField "int", "FIRMWARE_UPGRADE_RETRY_COUNT", "0"
-            // CATALOG_APP_PACKAGE_NAME: If a modification of the catalog apps's package
-            // name is done, this must be altered.
-            buildConfigField "String", "CATALOG_APP_PACKAGE_NAME", "\"org.wso2.app.catalog\""
-            // System service specific configurations.
-            // SYSTEM_APP_ENABLED: This is to set if the system app will also be installed.
-            // If this is set org.wso2.iot.system.service must also be available in the device.
-            buildConfigField "boolean", "SYSTEM_APP_ENABLED", "false"
-            // SYSTEM_SERVICE_PACKAGE: If system service app is in use, the package name of it is
-            // defined here so that the agent knows the package name of the system service to
-            // contact.
-            buildConfigField "String", "SYSTEM_SERVICE_PACKAGE", "\"org.wso2.iot.system.service\""
-            // HIDE_UNREGISTER_BUTTON: Hide the unregister button after enrollment so that  the
-            // unenrollment can only be done remotely.
-            buildConfigField "boolean", "HIDE_UNREGISTER_BUTTON", "false"
-            // Auto enrollment specific configurations
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED: This is to specify if the enrollment
-            // will be done in a background service. This is typically related to mutual SSL based
-            // enrollments only.
-            buildConfigField "boolean", "AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED", "false"
-            // SKIP_LICENSE: Skip displaying the license policy during enrollment.
-            // This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "SKIP_LICENSE", "false"
-            // HIDE_LOGIN_UI: Skip displaying the login screen during enrollment.
-            // This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "HIDE_LOGIN_UI", "false"
-            // SKIP_WORK_PROFILE_CREATION: This will hide the work profile creation step from the
-            // user. This is recommended to be used in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "SKIP_WORK_PROFILE_CREATION", "false"
-            // HIDE_ERROR_DIALOG: If this is set to true, agent will not show any error messages.
-            // This is only recommended to use when the enrollment happens in background, and no
-            // user interaction is needed. i.e in conjunction with
-            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "HIDE_ERROR_DIALOG", "false"
-            //Data publishing related configurations.
-            // LOG_PUBLISHER_IN_USE: By default DAS_PUBLISHER or SPLUNK_PUBLISHER are the allowed
-            // values. This specifies the log publisher to be used. This can be extended to write
-            // custom publishers.
-            buildConfigField "String", "LOG_PUBLISHER_IN_USE", "\"<SET_PUBLISHER>\""
-            // LOG_LEVEL: When publishing log cat output to server, the log level tobe used.
-            buildConfigField "String", "LOG_LEVEL", "\"*:W\""
-            // NUMBER_OF_LOG_LINES: Number of log lines to be sent.
-            buildConfigField "int", "NUMBER_OF_LOG_LINES", "500"
-            //Splunk related configurations
-            buildConfigField "String", "SPLUNK_API_KEY", "\"<SET_PUBLISHER>\""
-            // HEC_TOKEN: Allowed values are MINT or HTTP
-            buildConfigField "String", "SPLUNK_DATA_COLLECTOR_TYPE", "\"MINT\""
-            buildConfigField "String", "HEC_TOKEN", "\"<SPLUNK_HEC_TOKEN>\""
-            buildConfigField "String", "HEC_MINT_ENDPOINT_URL", "\"<SPLUNK_HEC_MINT_ENDPOINT_URL>\""
-            //Event publishing related configurations.
-            // If set to true, registered events will be published to DAS. There are two event
-            // publisher available by default and custom event types can be written and publihed
-            // with the provided extension points.
-            buildConfigField "boolean", "EVENT_LISTENING_ENABLED", "false"
-            // Listening to application state changes such as an app getting installed, uninstalled,
-            // upgraded and data cleared. If set to true, events will be published.
-            buildConfigField "boolean", "APPLICATION_STATE_LISTENER", "false"
-            // This is to listen to Runtime information such as CPU. If set to true,
-            // events will be published.
-            buildConfigField "boolean", "RUNTIME_STATE_LISTENER", "false"
-            // The time the alarm should first go off, in milliseconds. The default value is 1000.
-            buildConfigField "int", "DEFAULT_START_TIME", "10000"
-            // The interval between subsequent repeats of the alarm, in milliseconds.
-            // The default value is 30000.
-            buildConfigField "int", "DEFAULT_INTERVAL", "60000"
-            // The interval between subsequent repeats of the alarm, in milliseconds under FCM.
-            // The default value is 600000.
-            buildConfigField "int", "DEFAULT_FCM_INTERVAL", "600000"
-            // Enable background pull notifications strategy in order to fallback from FCM
-            // when there a FCM outage.
-            buildConfigField "boolean", "FCM_FALLBACK_PULL_ENABLED", "true"
-            buildConfigField "int", "DEFAULT_LISTENER_CODE", "10001"
-            // COSU related configurations.
-            // ALLOW_MULTIPLE_APPS_IN_COSU_MODE: Set to true to make all installed app in COSU mode
-            // accessible; if false only the last installation will be accessible.
-            buildConfigField "boolean", "ALLOW_MULTIPLE_APPS_IN_COSU_MODE", "true"
-            // By enabling this button, data wipe can be performed on a device without having to
-            // issue a remote wipe operation.
-            buildConfigField "boolean", "DISPLAY_WIPE_DEVICE_BUTTON", "true"
-            // Under COSU mode, this will enable an area in the screen to exit from screen pinned
-            // mode. This MUST be set to false in production, if COSU is used.
-            buildConfigField "boolean", "COSU_SECRET_EXIT", "true"
-            buildConfigField "String", "EULA_TITLE", "\"POLICY AGREEMENT\""
-            //Minimum Server API version that supported by the agent app
-            buildConfigField "float", "MIN_SERVER_API_VERSION", "1.0f"
-            //Maximum Server API version that supported by the agent app
-            buildConfigField "float", "MAX_SERVER_API_VERSION", "1.0f"
-            //Show notification to enable location if it is disabled
-            buildConfigField "boolean", "ASK_TO_ENABLE_LOCATION", "false"
-            //Publish location changes to server
-            buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "true"
-            //Collect WiFi scan results
-            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
+            buildConfigField("boolean", "COSU_SECRET_EXIT", "true")
         }
         debug {
+            debuggable true
+            signingConfig signingConfigs.debug
+
             // DEBUG_MODE_ENABLED: Make the agent print the debug logs.
             // Make this false in production.
-            buildConfigField "boolean", "DEBUG_MODE_ENABLED", "true"
-            // ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE: Setting this to true will make the
-            // App list response to the service to include system apps as well.
-            buildConfigField "boolean", "ALLOW_SYSTEM_APPS_IN_APPS_LIST_RESPONSE", "false"
+            buildConfigField("boolean", "DEBUG_MODE_ENABLED", "true")
+            // Under COSU mode, this will enable an area in the screen to exit from screen pinned
+            // mode. This MUST be set to false in production, if COSU is used.
+            buildConfigField("boolean", "COSU_SECRET_EXIT", "false")
+        }
+    }
+
+    // Since Gradle plugin version 3.0 every product flavor needs a flavor dimension
+    flavorDimensions "app", "enrollment", "type"
+    productFlavors {
+        cloud {
+            dimension "app"
             // Protocol used to communicate with the server. Valid values are http:// or https://
-            buildConfigField "String", "SERVER_PROTOCOL", "\"http://\""
-            buildConfigField "String", "API_SERVER_PORT", "\"80\""
-            //API version that supported by the server
-            buildConfigField "float", "SERVER_API_VERSION", "1.0f"
-            // Set DEFAULT_OWNERSHIP to null if no overriding is needed. Other possible values are,
-            // BYOD or COPE. If you are using the mutual SSL authentication
-            // This value must be set to a value other than null.
-            buildConfigField "String", "DEFAULT_OWNERSHIP", "\"BYOD\""
+            buildConfigField("String", "SERVER_PROTOCOL", "\"https://\"")
+            buildConfigField("String", "API_SERVER_PORT", "\"443\"")
             //DEFAULT_HOST - Hardcode the server host to avoid having the user type it during
             //enrollment. If the user must type the hostname/IP during enrollment, leave it as null.
-            buildConfigField "String", "DEFAULT_HOST", "null"
+            buildConfigField("String", "DEFAULT_HOST", "\"https://gateway.api.cloud.wso2.com\"")
             // APP_MANAGER_HOST: If the App store host is different from the DEFAULT_HOST
             // change this value.
-            buildConfigField "String", "APP_MANAGER_HOST", "null"
+            buildConfigField("String", "APP_MANAGER_HOST", "null")
             // CLOUD_MANAGER: If the App is pointed to cloud use cloud management host to resolve
             // tenants of user. Otherwise set this to null
-            buildConfigField "String", "CLOUD_MANAGER", "null"
+            buildConfigField("String", "CLOUD_MANAGER", "\"https://cloudmgt.cloud.wso2.com/cloudmgt\"")
             // SIGN_UP_URL: Set self registration link to sign up
-            buildConfigField "String", "SIGN_UP_URL", "null"
-            // AGENT_PACKAGE: If a modification of the agent's package name is done, this must be
-            // altered
-            buildConfigField "String", "AGENT_PACKAGE", "\"org.wso2.iot.agent\""
-            // FIRMWARE_UPGRADE_RETRY_COUNT: How many time the agent must retry if firmware upgrade
-            // fails.
-            buildConfigField "int", "FIRMWARE_UPGRADE_RETRY_COUNT", "0"
-            // CATALOG_APP_PACKAGE_NAME: If a modification of the catalog apps's package
-            // name is done, this must be altered.
-            buildConfigField "String", "CATALOG_APP_PACKAGE_NAME", "\"org.wso2.app.catalog\""
-            // System service specific configurations.
-            // SYSTEM_APP_ENABLED: This is to set if the system app will also be installed.
-            // If this is set org.wso2.iot.system.service must also be available in the device.
-            buildConfigField "boolean", "SYSTEM_APP_ENABLED", "false"
-            // SYSTEM_SERVICE_PACKAGE: If system service app is in use, the package name of it is
-            // defined here so that the agent knows the package name of the system service to
-            // contact.
-            buildConfigField "String", "SYSTEM_SERVICE_PACKAGE", "\"org.wso2.iot.system.service\""
-            // HIDE_UNREGISTER_BUTTON: Hide the unregister button after enrollment so that  the
-            // unenrollment can only be done remotely.
-            buildConfigField "boolean", "HIDE_UNREGISTER_BUTTON", "false"
+            buildConfigField("String", "SIGN_UP_URL", "\"http://wso2.com/iot/cloud/\"")
+            //Show notification to enable location if it is disabled
+            buildConfigField("boolean", "ASK_TO_ENABLE_LOCATION", "false")
+            //Publish location changes to server
+            buildConfigField("boolean", "LOCATION_PUBLISHING_ENABLED", "false")
+            //Collect WiFi scan results
+            buildConfigField("boolean", "WIFI_SCANNING_ENABLED", "false")
+        }
+        cloudStaging {
+            dimension "app"
+            // Protocol used to communicate with the server. Valid values are http:// or https://
+            buildConfigField("String", "SERVER_PROTOCOL", "\"https://\"")
+            buildConfigField("String", "API_SERVER_PORT", "\"8243\"")
+            //DEFAULT_HOST - Hardcode the server host to avoid having the user type it during
+            //enrollment. If the user must type the hostname/IP during enrollment, leave it as null.
+            buildConfigField("String", "DEFAULT_HOST", "\"https://gateway.api.cloudstaging.wso2.com\"")
+            // APP_MANAGER_HOST: If the App store host is different from the DEFAULT_HOST
+            // change this value.
+            buildConfigField("String", "APP_MANAGER_HOST", "null")
+            // CLOUD_MANAGER: If the App is pointed to cloud use cloud management host to resolve
+            // tenants of user. Otherwise set this to null
+            buildConfigField("String", "CLOUD_MANAGER", "\"https://cloudmgt.cloudstaging.wso2.com/cloudmgt\"")
+            // SIGN_UP_URL: Set self registration link to sign up
+            buildConfigField("String", "SIGN_UP_URL", "\"http://wso2.com/iot/cloud/\"")
+            //Show notification to enable location if it is disabled
+            buildConfigField("boolean", "ASK_TO_ENABLE_LOCATION", "false")
+            //Publish location changes to server
+            buildConfigField("boolean", "LOCATION_PUBLISHING_ENABLED", "false")
+            //Collect WiFi scan results
+            buildConfigField("boolean", "WIFI_SCANNING_ENABLED", "false")
+        }
+        standalone {
+            dimension "app"
+            // Protocol used to communicate with the server. Valid values are http:// or https://
+            buildConfigField("String", "SERVER_PROTOCOL", "\"http://\"")
+            buildConfigField("String", "API_SERVER_PORT", "\"80\"")
+            //DEFAULT_HOST - Hardcode the server host to avoid having the user type it during
+            //enrollment. If the user must type the hostname/IP during enrollment, leave it as null.
+            buildConfigField("String", "DEFAULT_HOST", "null")
+            // APP_MANAGER_HOST: If the App store host is different from the DEFAULT_HOST
+            // change this value.
+            buildConfigField("String", "APP_MANAGER_HOST", "null")
+            // CLOUD_MANAGER: If the App is pointed to cloud use cloud management host to resolve
+            // tenants of user. Otherwise set this to null
+            buildConfigField("String", "CLOUD_MANAGER", "null")
+            // SIGN_UP_URL: Set self registration link to sign up
+            buildConfigField("String", "SIGN_UP_URL", "null")
+            //Show notification to enable location if it is disabled
+            buildConfigField("boolean", "ASK_TO_ENABLE_LOCATION", "false")
+            //Publish location changes to server
+            buildConfigField("boolean", "LOCATION_PUBLISHING_ENABLED", "false")
+            //Collect WiFi scan results
+            buildConfigField("boolean", "WIFI_SCANNING_ENABLED", "true")
+
+            // Provide fallback for :iDPProxy library
+            matchingFallbacks = ['standalone']
+        }
+        autoEnrollmentEnabled {
+            dimension "enrollment"
             // Auto enrollment specific configurations
             // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED: This is to specify if the enrollment
             // will be done in a background service. This is typically related to mutual SSL based
             // enrollments only.
-            buildConfigField "boolean", "AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED", "false"
+            buildConfigField("boolean", "AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED", "true")
             // SKIP_LICENSE: Skip displaying the license policy during enrollment.
             // This is recommended to be used in conjunction with
             // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "SKIP_LICENSE", "false"
+            buildConfigField("boolean", "SKIP_LICENSE", "true")
             // HIDE_LOGIN_UI: Skip displaying the login screen during enrollment.
             // This is recommended to be used in conjunction with
             // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "HIDE_LOGIN_UI", "false"
+            buildConfigField("boolean", "HIDE_LOGIN_UI", "true")
             // SKIP_WORK_PROFILE_CREATION: This will hide the work profile creation step from the
             // user. This is recommended to be used in conjunction with
             // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "SKIP_WORK_PROFILE_CREATION", "false"
+            buildConfigField("boolean", "SKIP_WORK_PROFILE_CREATION", "true")
             // HIDE_ERROR_DIALOG: If this is set to true, agent will not show any error messages.
             // This is only recommended to use when the enrollment happens in background, and no
             // user interaction is needed. i.e in conjunction with
             // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
-            buildConfigField "boolean", "HIDE_ERROR_DIALOG", "false"
-            //Data publishing related configurations.
-            // LOG_PUBLISHER_IN_USE: By default DAS_PUBLISHER or SPLUNK_PUBLISHER are the allowed
-            // values. This specifies the log publisher to be used. This can be extended to write
-            // custom publishers.
-            buildConfigField "String", "LOG_PUBLISHER_IN_USE", "\"<SET_PUBLISHER>\""
-            // LOG_LEVEL: When publishing log cat output to server, the log level tobe used.
-            buildConfigField "String", "LOG_LEVEL", "\"*:W\""
-            // NUMBER_OF_LOG_LINES: Number of log lines to be sent.
-            buildConfigField "int", "NUMBER_OF_LOG_LINES", "500"
-            //Splunk related configurations
-            buildConfigField "String", "SPLUNK_API_KEY", "\"<SET_PUBLISHER>\""
-            // HEC_TOKEN: Allowed values are MINT or HTTP
-            buildConfigField "String", "SPLUNK_DATA_COLLECTOR_TYPE", "\"MINT\""
-            buildConfigField "String", "HEC_TOKEN", "\"<SPLUNK_HEC_TOKEN>\""
-            buildConfigField "String", "HEC_MINT_ENDPOINT_URL", "\"<SPLUNK_HEC_MINT_ENDPOINT_URL>\""
-            //Event publishing related configurations.
-            // If set to true, registered events will be published to DAS. There are two event
-            // publisher available by default and custom event types can be written and publihed
-            // with the provided extension points.
-            buildConfigField "boolean", "EVENT_LISTENING_ENABLED", "false"
-            // Listening to application state changes such as an app getting installed, uninstalled,
-            // upgraded and data cleared. If set to true, events will be published.
-            buildConfigField "boolean", "APPLICATION_STATE_LISTENER", "false"
-            // This is to listen to Runtime information such as CPU. If set to true,
-            // events will be published.
-            buildConfigField "boolean", "RUNTIME_STATE_LISTENER", "false"
-            // The time the alarm should first go off, in milliseconds. The default value is 1000.
-            buildConfigField "int", "DEFAULT_START_TIME", "10000"
-            // The interval between subsequent repeats of the alarm, in milliseconds.
-            // The default value is 30000.
-            buildConfigField "int", "DEFAULT_INTERVAL", "60000"
-            // The interval between subsequent repeats of the alarm, in milliseconds under FCM.
-            // The default value is 600000.
-            buildConfigField "int", "DEFAULT_FCM_INTERVAL", "600000"
-            // Enable background pull notifications strategy in order to fallback from FCM
-            // when there a FCM outage.
-            buildConfigField "boolean", "FCM_FALLBACK_PULL_ENABLED", "true"
-            buildConfigField "int", "DEFAULT_LISTENER_CODE", "10001"
-            // COSU related configurations.
-            // ALLOW_MULTIPLE_APPS_IN_COSU_MODE: Set to true to make all installed app in COSU mode
-            // accessible; if false only the last installation will be accessible.
-            buildConfigField "boolean", "ALLOW_MULTIPLE_APPS_IN_COSU_MODE", "true"
-            // By enabling this button, data wipe can be performed on a device without having to
-            // issue a remote wipe operation.
-            buildConfigField "boolean", "DISPLAY_WIPE_DEVICE_BUTTON", "true"
-            // Under COSU mode, this will enable an area in the screen to exit from screen pinned
-            // mode. This MUST be set to false in production, if COSU is used.
-            buildConfigField "boolean", "COSU_SECRET_EXIT", "true"
-            buildConfigField "String", "EULA_TITLE", "\"POLICY AGREEMENT\""
-            //Minimum Server API version that supported by the agent app
-            buildConfigField "float", "MIN_SERVER_API_VERSION", "1.0f"
-            //Maximum Server API version that supported by the agent app
-            buildConfigField "float", "MAX_SERVER_API_VERSION", "1.0f"
-            //Show notification to enable location if it is disabled
-            buildConfigField "boolean", "ASK_TO_ENABLE_LOCATION", "false"
-            //Publish location changes to server
-            buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "true"
-            //Collect WiFi scan results
-            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
+            buildConfigField("boolean", "HIDE_ERROR_DIALOG", "true")
+        }
+        autoEnrollmentDisabled {
+            dimension "enrollment"
+            // Auto enrollment specific configurations
+            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED: This is to specify if the enrollment
+            // will be done in a background service. This is typically related to mutual SSL based
+            // enrollments only.
+            buildConfigField("boolean", "AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED", "false")
+            // SKIP_LICENSE: Skip displaying the license policy during enrollment.
+            // This is recommended to be used in conjunction with
+            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
+            buildConfigField("boolean", "SKIP_LICENSE", "true")
+            // HIDE_LOGIN_UI: Skip displaying the login screen during enrollment.
+            // This is recommended to be used in conjunction with
+            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
+            buildConfigField("boolean", "HIDE_LOGIN_UI", "false")
+            // SKIP_WORK_PROFILE_CREATION: This will hide the work profile creation step from the
+            // user. This is recommended to be used in conjunction with
+            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
+            buildConfigField("boolean", "SKIP_WORK_PROFILE_CREATION", "true")
+            // HIDE_ERROR_DIALOG: If this is set to true, agent will not show any error messages.
+            // This is only recommended to use when the enrollment happens in background, and no
+            // user interaction is needed. i.e in conjunction with
+            // AUTO_ENROLLMENT_BACKGROUND_SERVICE_ENABLED
+            buildConfigField("boolean", "HIDE_ERROR_DIALOG", "false")
+        }
+        BYOD {
+            dimension "type"
+            // Set DEFAULT_OWNERSHIP to null if no overriding is needed. Other possible values are,
+            // BYOD or COPE. If you are using the mutual SSL authentication
+            // This value must be set to a value other than null.
+            buildConfigField("String", "DEFAULT_OWNERSHIP", "\"BYOD\"")
+            // System service specific configurations.
+            // SYSTEM_APP_ENABLED: This is to set if the system app will also be installed.
+            // If this is set org.wso2.iot.system.service must also be available in the device.
+            buildConfigField("boolean", "SYSTEM_APP_ENABLED", "false")
+        }
+        COPE {
+            dimension "type"
+            // Set DEFAULT_OWNERSHIP to null if no overriding is needed. Other possible values are,
+            // BYOD or COPE. If you are using the mutual SSL authentication
+            // This value must be set to a value other than null.
+            buildConfigField("String", "DEFAULT_OWNERSHIP", "\"COPE\"")
+            // System service specific configurations.
+            // SYSTEM_APP_ENABLED: This is to set if the system app will also be installed.
+            // If this is set org.wso2.iot.system.service must also be available in the device.
+            buildConfigField("boolean", "SYSTEM_APP_ENABLED", "true")
         }
     }
     compileOptions {
@@ -728,42 +325,38 @@ task checkAPIVersion(dependsOn: build) {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    androidTestCompile 'org.apache.ftpserver:ftpserver-core:1.1.1'
-    androidTestCompile 'org.apache.sshd:sshd-sftp:0.11.0'
-    androidTestCompile 'org.apache.ftpserver:ftplet-api:1.1.1'
-    androidTestCompile 'com.android.support:support-annotations:25.4.0'
-    androidTestCompile 'com.android.support.test:runner:1.0.1'
-    androidTestCompile 'com.android.support.test:rules:1.0.1'
-    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'org.apache.ftpserver:ftpserver-core:1.1.1'
+    androidTestImplementation 'org.apache.sshd:sshd-sftp:0.11.0'
+    androidTestImplementation 'org.apache.ftpserver:ftplet-api:1.1.1'
+    androidTestImplementation 'com.android.support:support-annotations:27.1.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    releaseCompile project(path: ':iDPProxy', configuration: 'release')
-    stagingCompile project(path: ':iDPProxy', configuration: 'staging')
-    standaloneCompile project(path: ':iDPProxy', configuration: 'standalone')
-    debugCopeCompile project(path: ':iDPProxy', configuration: 'debug')
-    debugCompile project(path: ':iDPProxy', configuration: 'debug')
+    implementation project(':iDPProxy')
     compile('com.googlecode.json-simple:json-simple:1.1.1') {
         exclude module: 'junit'
     }
-    compile 'com.android.support:appcompat-v7:25.4.0'
-    compile 'com.android.support:design:25.4.0'
-    compile 'commons-io:commons-io:2.5'
-    compile 'com.google.android.gms:play-services-base:11.8.0'
-    compile "com.google.android.gms:play-services-location:11.8.0"
-    compile 'com.google.firebase:firebase-core:11.8.0'
-    compile 'com.google.firebase:firebase-messaging:11.8.0'
-    compile 'com.fasterxml.jackson.core:jackson-core:2.6.4'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.6.4'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.6.4'
-    compile 'org.bouncycastle:bcprov-jdk16:1.46'
-    compile 'com.google.code.gson:gson:2.8.0'
-    compile 'com.splunk.mint:mint:5.0.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'com.jcraft:jsch:0.1.54'
-    compile 'commons-net:commons-net:3.3'
-    compile "org.java-websocket:Java-WebSocket:1.3.0"
+    implementation 'com.android.support:appcompat-v7:27.1.0'
+    implementation 'com.android.support:design:27.1.0'
+    implementation 'commons-io:commons-io:2.5'
+    implementation 'com.google.android.gms:play-services-base:11.8.0'
+    implementation "com.google.android.gms:play-services-location:11.8.0"
+    implementation 'com.google.firebase:firebase-core:11.8.0'
+    implementation 'com.google.firebase:firebase-messaging:11.8.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.6.4'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.6.4'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.6.4'
+    implementation 'org.bouncycastle:bcprov-jdk16:1.46'
+    implementation 'com.google.code.gson:gson:2.8.0'
+    implementation 'com.splunk.mint:mint:5.0.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.jcraft:jsch:0.1.54'
+    implementation 'commons-net:commons-net:3.3'
+    implementation "org.java-websocket:Java-WebSocket:1.3.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/client/client/build.gradle
+++ b/client/client/build.gradle
@@ -128,7 +128,7 @@ android {
             buildConfigField("boolean", "DEBUG_MODE_ENABLED", "false")
             // Under COSU mode, this will enable an area in the screen to exit from screen pinned
             // mode. This MUST be set to false in production, if COSU is used.
-            buildConfigField("boolean", "COSU_SECRET_EXIT", "true")
+            buildConfigField("boolean", "COSU_SECRET_EXIT", "false")
         }
         debug {
             debuggable true
@@ -139,7 +139,7 @@ android {
             buildConfigField("boolean", "DEBUG_MODE_ENABLED", "true")
             // Under COSU mode, this will enable an area in the screen to exit from screen pinned
             // mode. This MUST be set to false in production, if COSU is used.
-            buildConfigField("boolean", "COSU_SECRET_EXIT", "false")
+            buildConfigField("boolean", "COSU_SECRET_EXIT", "true")
         }
     }
 
@@ -214,9 +214,6 @@ android {
             buildConfigField("boolean", "LOCATION_PUBLISHING_ENABLED", "false")
             //Collect WiFi scan results
             buildConfigField("boolean", "WIFI_SCANNING_ENABLED", "true")
-
-            // Provide fallback for :iDPProxy library
-            matchingFallbacks = ['standalone']
         }
         autoEnrollmentEnabled {
             dimension "enrollment"

--- a/client/gradle/wrapper/gradle-wrapper.properties
+++ b/client/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 21 11:05:48 IST 2017
+#Wed Mar 14 09:51:17 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/client/iDPProxy/build.gradle
+++ b/client/iDPProxy/build.gradle
@@ -17,13 +17,30 @@
  */
 apply plugin: 'com.android.library'
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
     publishNonDefault true
 
     defaultConfig {
         minSdkVersion 17
-        targetSdkVersion 25
+        targetSdkVersion 27
+
+        // APPLICATION_PACKAGE: If a modification of the agent's package name is done, this must
+        // be altered.
+        buildConfigField "String", "APPLICATION_PACKAGE", "\"org.wso2.iot.agent\""
+        // TRUSTSTORE_PASSWORD: Password of the trust store to be used in SSL. BKS truststore
+        // holds all the public certificates of the servers that the agent should trust.
+        buildConfigField "String", "TRUSTSTORE_PASSWORD", "\"wso2carbon\""
+        // KEYSTORE_PASSWORD: Password of the key store to be used in SSL. BKS keystore
+        // holds the client's own certificate and key pair if needed.
+        // This is needed in situations such as mutual SSL authentication.
+        buildConfigField "String", "KEYSTORE_PASSWORD", "\"wso2carbon\""
+        // TRUSTSTORE_LOCATION: If the truststore BKS must be picked from a file path at runtime
+        // instead of storing it in the complile time, change this value.
+        buildConfigField "String", "TRUSTSTORE_LOCATION", "null"
+        // KEYSTORE_LOCATION: If the keystore BKS must be picked from a file path at runtime
+        // instead of storing it in the complile time, change this value.
+        buildConfigField "String", "KEYSTORE_LOCATION", "null"
     }
 
     buildTypes {
@@ -33,6 +50,20 @@ android {
             // DEBUG_MODE_ENABLED: Make the agent print the debug logs.
             // Make this false in production.
             buildConfigField "boolean", "DEBUG_MODE_ENABLED", "false"
+        }
+        debug {
+            // DEBUG_MODE_ENABLED: Make the agent print the debug logs.
+            // Make this false in production.
+            buildConfigField "boolean", "DEBUG_MODE_ENABLED", "true"
+            debuggable true
+        }
+    }
+
+    // Since Gradle plugin version 3.0 every product flavor needs a flavor dimension
+    flavorDimensions "app"
+    productFlavors {
+        cloud {
+            dimension "app"
             // AUTHENTICATOR_IN_USE: Type of authenticator to be used when authenticating with
             // server. Allowed values by default are OAUTH_AUTHENTICATOR or MUTUAL_SSL_AUTHENTICATOR
             buildConfigField "String", "AUTHENTICATOR_IN_USE", "\"OAUTH_AUTHENTICATOR\""
@@ -46,27 +77,9 @@ android {
             buildConfigField "String", "SERVER_PROTOCOL", "\"https://\""
             buildConfigField "int", "API_HTTP_SERVER_PORT", "80"
             buildConfigField "int", "API_HTTPS_SERVER_PORT", "443"
-            // TRUSTSTORE_PASSWORD: Password of the trust store to be used in SSL. BKS truststore
-            // holds all the public certificates of the servers that the agent should trust.
-            buildConfigField "String", "TRUSTSTORE_PASSWORD", "\"wso2carbon\""
-            // KEYSTORE_PASSWORD: Password of the key store to be used in SSL. BKS keystore
-            // holds the client's own certificate and key pair if needed.
-            // This is needed in situations such as mutual SSL authentication.
-            buildConfigField "String", "KEYSTORE_PASSWORD", "\"wso2carbon\""
-            // TRUSTSTORE_LOCATION: If the truststore BKS must be picked from a file path at runtime
-            // instead of storing it in the complile time, change this value.
-            buildConfigField "String", "TRUSTSTORE_LOCATION", "null"
-            // KEYSTORE_LOCATION: If the keystore BKS must be picked from a file path at runtime
-            // instead of storing it in the complile time, change this value.
-            buildConfigField "String", "KEYSTORE_LOCATION", "null"
-            // APPLICATION_PACKAGE: If a modification of the agent's package name is done, this must
-            // be altered.
-            buildConfigField "String", "APPLICATION_PACKAGE", "\"org.wso2.iot.agent\""
         }
-
-        staging {
-            initWith debug
-            buildConfigField "boolean", "DEBUG_MODE_ENABLED", "true"
+        cloudStaging {
+            dimension "app"
             // AUTHENTICATOR_IN_USE: Type of authenticator to be used when authenticating with
             // server. Allowed values by default are OAUTH_AUTHENTICATOR or MUTUAL_SSL_AUTHENTICATOR
             buildConfigField "String", "AUTHENTICATOR_IN_USE", "\"OAUTH_AUTHENTICATOR\""
@@ -80,29 +93,9 @@ android {
             buildConfigField "String", "SERVER_PROTOCOL", "\"https://\""
             buildConfigField "int", "API_HTTP_SERVER_PORT", "8280"
             buildConfigField "int", "API_HTTPS_SERVER_PORT", "8243"
-            // TRUSTSTORE_PASSWORD: Password of the trust store to be used in SSL. BKS truststore
-            // holds all the public certificates of the servers that the agent should trust.
-            buildConfigField "String", "TRUSTSTORE_PASSWORD", "\"wso2carbon\""
-            // KEYSTORE_PASSWORD: Password of the key store to be used in SSL. BKS keystore
-            // holds the client's own certificate and key pair if needed.
-            // This is needed in situations such as mutual SSL authentication.
-            buildConfigField "String", "KEYSTORE_PASSWORD", "\"wso2carbon\""
-            // TRUSTSTORE_LOCATION: If the truststore BKS must be picked from a file path at runtime
-            // instead of storing it in the complile time, change this value.
-            buildConfigField "String", "TRUSTSTORE_LOCATION", "null"
-            // KEYSTORE_LOCATION: If the keystore BKS must be picked from a file path at runtime
-            // instead of storing it in the complile time, change this value.
-            buildConfigField "String", "KEYSTORE_LOCATION", "null"
-            // APPLICATION_PACKAGE: If a modification of the agent's package name is done, this must
-            // be altered.
-            buildConfigField "String", "APPLICATION_PACKAGE", "\"org.wso2.iot.agent\""
-            debuggable true
         }
-
         standalone {
-            // DEBUG_MODE_ENABLED: Make the agent print the debug logs.
-            // Make this false in production.
-            buildConfigField "boolean", "DEBUG_MODE_ENABLED", "false"
+            dimension "app"
             // AUTHENTICATOR_IN_USE: Type of authenticator to be used when authenticating with
             // server. Allowed values by default are OAUTH_AUTHENTICATOR or MUTUAL_SSL_AUTHENTICATOR
             buildConfigField "String", "AUTHENTICATOR_IN_USE", "\"OAUTH_AUTHENTICATOR\""
@@ -116,59 +109,9 @@ android {
             buildConfigField "String", "SERVER_PROTOCOL", "\"http://\""
             buildConfigField "int", "API_HTTP_SERVER_PORT", "8280"
             buildConfigField "int", "API_HTTPS_SERVER_PORT", "8243"
-            // TRUSTSTORE_PASSWORD: Password of the trust store to be used in SSL. BKS truststore
-            // holds all the public certificates of the servers that the agent should trust.
-            buildConfigField "String", "TRUSTSTORE_PASSWORD", "\"wso2carbon\""
-            // KEYSTORE_PASSWORD: Password of the key store to be used in SSL. BKS keystore
-            // holds the client's own certificate and key pair if needed.
-            // This is needed in situations such as mutual SSL authentication.
-            buildConfigField "String", "KEYSTORE_PASSWORD", "\"wso2carbon\""
-            // TRUSTSTORE_LOCATION: If the truststore BKS must be picked from a file path at runtime
-            // instead of storing it in the complile time, change this value.
-            buildConfigField "String", "TRUSTSTORE_LOCATION", "null"
-            // KEYSTORE_LOCATION: If the keystore BKS must be picked from a file path at runtime
-            // instead of storing it in the complile time, change this value.
-            buildConfigField "String", "KEYSTORE_LOCATION", "null"
-            // APPLICATION_PACKAGE: If a modification of the agent's package name is done, this must
-            // be altered.
-            buildConfigField "String", "APPLICATION_PACKAGE", "\"org.wso2.iot.agent\""
-        }
-
-        debug {
-            // DEBUG_MODE_ENABLED: Make the agent print the debug logs.
-            // Make this false in production.
-            buildConfigField "boolean", "DEBUG_MODE_ENABLED", "true"
-            // AUTHENTICATOR_IN_USE: Type of authenticator to be used when authenticating with
-            // server. Allowed values by default are OAUTH_AUTHENTICATOR or MUTUAL_SSL_AUTHENTICATOR
-            buildConfigField "String", "AUTHENTICATOR_IN_USE", "\"OAUTH_AUTHENTICATOR\""
-            // HTTP_CLIENT_IN_USE: Http client to be used for communication. Allowed values are,
-            // MUTUAL_HTTP_CLIENT or OAUTH_HTTP_CLIENT
-            buildConfigField "String", "HTTP_CLIENT_IN_USE", "\"OAUTH_HTTP_CLIENT\""
-            // DEFAULT_TIME_OUT: Default connection time out when connecting to the backend
-            buildConfigField "int", "DEFAULT_TIME_OUT", "60000"
-            // SERVER_PROTOCOL: Protocol used to communicate with the server.
-            // Valid values are http:// or https://
-            buildConfigField "String", "SERVER_PROTOCOL", "\"http://\""
-            buildConfigField "int", "API_HTTP_SERVER_PORT", "8280"
-            buildConfigField "int", "API_HTTPS_SERVER_PORT", "8243"
-            // TRUSTSTORE_PASSWORD: Password of the trust store to be used in SSL. BKS truststore
-            // holds all the public certificates of the servers that the agent should trust.
-            buildConfigField "String", "TRUSTSTORE_PASSWORD", "\"wso2carbon\""
-            // KEYSTORE_PASSWORD: Password of the key store to be used in SSL. BKS keystore
-            // holds the client's own certificate and key pair if needed.
-            // This is needed in situations such as mutual SSL authentication.
-            buildConfigField "String", "KEYSTORE_PASSWORD", "\"wso2carbon\""
-            // TRUSTSTORE_LOCATION: If the truststore BKS must be picked from a file path at runtime
-            // instead of storing it in the complile time, change this value.
-            buildConfigField "String", "TRUSTSTORE_LOCATION", "null"
-            // KEYSTORE_LOCATION: If the keystore BKS must be picked from a file path at runtime
-            // instead of storing it in the complile time, change this value.
-            buildConfigField "String", "KEYSTORE_LOCATION", "null"
-            // APPLICATION_PACKAGE: If a modification of the agent's package name is done, this must
-            // be altered.
-            buildConfigField "String", "APPLICATION_PACKAGE", "\"org.wso2.iot.agent\""
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
@@ -176,6 +119,6 @@ android {
 }
 
 dependencies {
-    compile 'commons-codec:commons-codec:20041127.091804'
-    compile 'com.android.volley:volley:1.0.0'
+    api 'commons-codec:commons-codec:20041127.091804'
+    api 'com.android.volley:volley:1.0.0'
 }


### PR DESCRIPTION
Upgrading to SDK 27 allows use of the newest gradle plugin. The gradle build files of the client and the iDPProxy have been reworked in order to provide the following flavour dimensions:
- app (cloud, cloudStaging, standalone)
- enrollment (autoEnrollmentDisabled, autoEnrollmentEnabled)
- type (BYOD, COPE)

Using product flavors it is easier to build different versions of the app in different build variants (release, debug). Including common configurations in the defaultConfig section eliminates some of the repetitions made.

## Goals
> Given a user with less knowledge in how to change build files it is easier to select and build specific build flavors

## Release note
> Use product flavors instead of build variants to determine app variant
> Upgraded target API level to 27

## Documentation
> This change impacts most of the documentation populating build file changes.

## Test environment
> JDK 1.8 Update 162
> Android Studio 3.0.1
> Tested on android 7.0 and android 8.1