### PR TITLE
Add lock to prevent multiple pending operation call in critical path

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/services/AlarmReceiver.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/AlarmReceiver.java
@@ -75,6 +75,7 @@ public class AlarmReceiver extends BroadcastReceiver {
 
 		} else {
 			if (Constants.DEBUG_MODE_ENABLED) {
+				Log.v(TAG, intent.toUri(0));
 				Log.d(TAG, "Recurring alarm; Polling pending operations");
 			}
 			OperationTask operationTask = new OperationTask();


### PR DESCRIPTION
## Purpose
> Add lock to prevent multiple pending operation call in critical path

## Goals
> Prevent having multiple pending operation calls simultaneously.

## Approach
> Add in memory lock to prevent multiple pending operation call in critical path

## User stories
> N/A

## Release note
> Add lock to prevent multiple pending operation call in critical path

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> Cannot automate

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> No

## Migrations (if applicable)
> Upgradable from previous release

## Test environment
> Android API 23
 
## Learning
> N/A