### PR TITLE
Fix for no more polling if date modified to future and then set to cu…

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/services/AlarmReceiver.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/AlarmReceiver.java
@@ -75,7 +75,7 @@ public class AlarmReceiver extends BroadcastReceiver {
 
 		} else {
 			if (Constants.DEBUG_MODE_ENABLED) {
-				Log.v(TAG, intent.toUri(0));
+				Log.v(TAG, "Recurring alarm; intent URI: " + intent.toUri(0));
 				Log.d(TAG, "Recurring alarm; Polling pending operations");
 			}
 			OperationTask operationTask = new OperationTask();

--- a/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
@@ -146,9 +146,9 @@ public class MessageProcessor implements APIResultCallBack {
 		long currentTime = System.currentTimeMillis();
 		if (isInCriticalPath) {
 			// We need to make sure sync won't stale under any circumstances.
-			// So we are allowing time up to default http time out for a single sync.
-			if (lastSyncAt + org.wso2.emm.agent.proxy.utils.Constants.HttpClient.DEFAULT_TIME_OUT
-					> currentTime) {
+			// So we are allowing time up to default http timeout for a single sync.
+			if (lastSyncAt < currentTime
+					&& lastSyncAt + org.wso2.emm.agent.proxy.utils.Constants.HttpClient.DEFAULT_TIME_OUT > currentTime) {
 				Log.w(TAG, "Ignoring polling attempt since another polling is ongoing.");
 				return;
 			}


### PR DESCRIPTION
## Purpose
> Fix for no more polling if date modified to future and then set to current. Improve log text.

## Goals
> Fix edge case issue in no more polling is possible if device date set to future from now, then set it back to the current time. Improve log text as requested in https://github.com/wso2/cdmf-agent-android/pull/166#pullrequestreview-105033895

## Approach
> Modify condition to prevent polling issue with time modifications.

## Approach
> Add in memory lock to prevent multiple pending operation call in critical path

## User stories
> N/A

## Release note
> Add lock to prevent multiple pending operation call in critical path

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> Cannot automate

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> No

## Migrations (if applicable)
> Upgradable from previous release

## Test environment
> Android API 23
 
## Learning
> N/A