### PR TITLE
Fix functionality to retrieve Android device CPU info at enrollment

### DIFF
--- a/client/client/build.gradle
+++ b/client/client/build.gradle
@@ -774,6 +774,7 @@ dependencies {
     compile 'com.jcraft:jsch:0.1.54'
     compile 'commons-net:commons-net:3.3'
     compile "org.java-websocket:Java-WebSocket:1.3.0"
+    compile "org.apache.commons:commons-lang3:3.6"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/client/client/src/main/java/org/wso2/iot/agent/api/RuntimeInfo.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/api/RuntimeInfo.java
@@ -64,19 +64,17 @@ public class RuntimeInfo {
         Device.Property property;
         if (Build.VERSION.SDK_INT < 26) {
             for (String topCommandRow : topCommandRows) {
-                String[] columns = topCommandRow.split(", ");
-                for (String column : columns) {
-                    if (!column.equals("")) {
+                if (topCommandRow != null && !topCommandRow.isEmpty()) {
+                    String[] columns = topCommandRow.split(", ");
+                    for (String column : columns) {
                         String[] keyValue = column.split(" ");
                         property = new Device.Property();
                         property.setName(keyValue[0]);
                         property.setValue(keyValue[1]);
                         properties.add(property);
-                    } else {
-                        continue;
                     }
+                    break;
                 }
-                break;
             }
         } else {
             for (String topCommandRow : topCommandRows) {


### PR DESCRIPTION
## Purpose
> When an Android device is being enrolled, the device sends a payload with device CPU info to the IoT Server. This data is not displayed or processed, rather simply stored. 
Since a separate API does not exist to retrieve this data, it is read from a format provided by the Android OS. However, this format sometimes changes by Android version and even manufacturer.

> While testing this Android agent on a OnePlus 5T device it refused to launch. Further investigation showed that the issue lay in how the details format was arranged in this particular device by the OEM. The irregular layout caused an exception to occur and ultimately stopped the agent from launching in the device.
In certain Android versions, while the app does not break/crash, the data retrieved is often incorrect.

> This PR is intended to fix issues when reading CPU info data from certain Android versions and stop the agent crashing on the OnePlus 5T device.

## Goals
> Retrieve correct CPU info data from certain Android versions (API 22 and upwards).

## Approach
> - Added conditional clauses to check for Android API version and extract data based on the result.
> - Added regex functions to check for version unique characters and strings in the CPU info format

## User stories
> N/A

## Release note
> Fixes functionality for retrieving Android device CPU info at enrollment.

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Java version: 1.8.0_141, vendor: Oracle Corporation
Java home: /usr/lib/jvm/jdk1.8.0_141/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux"
 
## Learning
> Dependencies added: [org.apache.commons:commons-lang3:3.6](https://mvnrepository.com/artifact/org.apache.commons/commons-lang3/3.6)