### PR TITLE
Prevent OTA operations staling when System service stopped

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
@@ -236,11 +236,37 @@ public class MessageProcessor implements APIResultCallBack {
 								isUpgradeTriggered = false;
 							} else if (opId == 0) {
 								Preference.putInt(context, "firmwareOperationId", operation.getId());
+								Preference.putLong(context,
+										Constants.PreferenceFlag.FIRMWARE_UPGRADE_INITIATED_AT,
+										System.currentTimeMillis());
 								isUpgradeTriggered = true;
 							} else if (operation.getId() != 0 && operation.getId() != opId){
-								Log.e(TAG, "This is a new Firmware upgrade operation but one operation is still on " +
-                                        "going");
-								queuedFirmwareOperationlist.add(operation.getId());
+								long previousUpgradeInitiatedAt = Preference.getLong(context,
+										Constants.PreferenceFlag.FIRMWARE_UPGRADE_INITIATED_AT);
+								currentTime = System.currentTimeMillis();
+								if (previousUpgradeInitiatedAt < currentTime && previousUpgradeInitiatedAt
+										+ Constants.FIRMWARE_DOWNLOAD_OPERATION_TIMEOUT > currentTime) {
+									Log.e(TAG, "This is a new Firmware upgrade operation but one operation " +
+											"is still on going");
+									queuedFirmwareOperationlist.add(operation.getId());
+								} else {
+									Preference.putInt(context, "firmwareOperationId", operation.getId());
+									Preference.putLong(context,
+											Constants.PreferenceFlag.FIRMWARE_UPGRADE_INITIATED_AT,
+											System.currentTimeMillis());
+									org.wso2.emm.agent.beans.Operation firmwareOperation = new org.wso2.emm.agent.beans.Operation();
+									firmwareOperation.setId(opId);
+									firmwareOperation.setCode(Constants.Operation.UPGRADE_FIRMWARE);
+									firmwareOperation.setStatus(ERROR_STATE);
+									firmwareOperation.setOperationResponse("Operation timed out.");
+									if (replyPayload != null) {
+										replyPayload.add(firmwareOperation);
+									} else {
+										replyPayload = new ArrayList<>();
+										replyPayload.add(firmwareOperation);
+									}
+									isUpgradeTriggered = true;
+								}
 							}
                             //Operation Id of the received reply payload is stored
                             firmwareUpgradeOperationId = operation.getId();

--- a/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
@@ -254,7 +254,8 @@ public class MessageProcessor implements APIResultCallBack {
 									Preference.putLong(context,
 											Constants.PreferenceFlag.FIRMWARE_UPGRADE_INITIATED_AT,
 											System.currentTimeMillis());
-									org.wso2.emm.agent.beans.Operation firmwareOperation = new org.wso2.emm.agent.beans.Operation();
+									org.wso2.emm.agent.beans.Operation firmwareOperation
+											= new org.wso2.emm.agent.beans.Operation();
 									firmwareOperation.setId(opId);
 									firmwareOperation.setCode(Constants.Operation.UPGRADE_FIRMWARE);
 									firmwareOperation.setStatus(ERROR_STATE);

--- a/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
@@ -59,6 +59,8 @@ public class Constants {
 	public static final int APP_DOWNLOAD_TIMEOUT = 30 * 60 * 1000;
 	public static final int APP_INSTALL_TIMEOUT = 10 * 60 * 1000;
 	public static final int APP_UNINSTALL_TIMEOUT = 10 * 60 * 1000;
+    //Should be grater than FIRMWARE_DOWNLOAD_TIMEOUT in the system service.
+    public static final int FIRMWARE_DOWNLOAD_OPERATION_TIMEOUT = 6 * 60 * 1000;
 
 	// This is used to skip the license
 	public static final boolean SKIP_LICENSE = false;
@@ -484,6 +486,7 @@ public class Constants {
 		public static final String APPLIED_POLICY = "appliedPolicy";
 		public static final String IS_AGREED = "isAgreed";
 		public static final String NOTIFIER_TYPE = "notifierType";
+		public static final String FIRMWARE_UPGRADE_INITIATED_AT = "firmwareUpgradeInitiatedAt";
 		public static final String DOWNLOAD_INITIATED_AT = "downloadInitiatedAt";
 		public static final String INSTALLATION_INITIATED_AT = "installationInitiatedAt";
 		public static final String UNINSTALLATION_INITIATED_AT = "uninstallationInitiatedAt";

--- a/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
@@ -59,8 +59,8 @@ public class Constants {
 	public static final int APP_DOWNLOAD_TIMEOUT = 30 * 60 * 1000;
 	public static final int APP_INSTALL_TIMEOUT = 10 * 60 * 1000;
 	public static final int APP_UNINSTALL_TIMEOUT = 10 * 60 * 1000;
-    //Should be grater than FIRMWARE_DOWNLOAD_TIMEOUT in the system service.
-    public static final int FIRMWARE_DOWNLOAD_OPERATION_TIMEOUT = 6 * 60 * 1000;
+	//Should be grater than FIRMWARE_DOWNLOAD_TIMEOUT in the system service.
+	public static final int FIRMWARE_DOWNLOAD_OPERATION_TIMEOUT = 6 * 60 * 1000;
 
 	// This is used to skip the license
 	public static final boolean SKIP_LICENSE = false;

--- a/system-service/app/src/main/java/org/wso2/emm/system/service/EMMSystemService.java
+++ b/system-service/app/src/main/java/org/wso2/emm/system/service/EMMSystemService.java
@@ -19,6 +19,7 @@
 package org.wso2.emm.system.service;
 
 import android.annotation.TargetApi;
+import android.app.DownloadManager;
 import android.app.IntentService;
 import android.app.admin.DevicePolicyManager;
 import android.content.ComponentName;
@@ -456,6 +457,22 @@ public class EMMSystemService extends IntentService {
      */
     public void upgradeFirmware(final boolean isStatusCheck) {
         Log.i(TAG, "An upgrade has been requested");
+        boolean isDownloadReferenceAvailable = Preference.getBoolean(this,
+                getResources().getString(R.string.download_manager_reference_id_available));
+        Log.d(TAG, "Download manager reference id availability: " + isDownloadReferenceAvailable);
+        long downloadReference = Preference.getLong(this,
+                getResources().getString(R.string.download_manager_reference_id));
+        if (isDownloadReferenceAvailable && downloadReference > 0) {
+            DownloadManager downloadManager = (DownloadManager) getSystemService(Context.DOWNLOAD_SERVICE);
+            if (downloadManager != null) {
+                downloadManager.remove(downloadReference);
+            }
+            Preference.putBoolean(this,
+                    getResources().getString(R.string.download_manager_reference_id_available), false);
+            Preference.putLong(this,
+                    getResources().getString(R.string.download_manager_reference_id), -1);
+            Log.i(TAG, "Removed stale download: " + downloadReference);
+        }
 
         Preference.putBoolean(context, context.getResources().getString(R.string.
                                                                                 firmware_status_check_in_progress), isStatusCheck);


### PR DESCRIPTION
## Purpose
> Prevent OTA operations staling when System service stopped

## Goals
> Prevent OTA operations staling when System service stopped

## Approach
> Add time stamp based timeout to prevent OTA operations from staling.

## User stories
> N/A

## Release note
> Prevent OTA operations staling when System service stopped

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> Able to migrate from previous version

## Test environment
> Android 5.1
 
## Learning
> N/A