### PR TITLE
Fixed operation staling issue in firmware upgrade

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/MessageProcessor.java
@@ -72,9 +72,8 @@ public class MessageProcessor implements APIResultCallBack {
 	private boolean isUpgradeTriggered = false;
 	private boolean isShellCommandTriggered = false;
 	private static final String ERROR_STATE = "ERROR";
-	private static final String COMPLETE_STATE = "COMPLETED";
+	private static final String IN_PROGRESS_STATE = "IN_PROGRESS";
 	private String shellCommand = null;
-	private List<Integer> queuedFirmwareOperationlist = new ArrayList<>();
 
 	/**
 	 * Local notification message handler.
@@ -170,7 +169,6 @@ public class MessageProcessor implements APIResultCallBack {
 		ObjectMapper mapper = new ObjectMapper();
 		int appInstallOperationId;
 		int appUninstallOperationId;
-		int firmwareUpgradeOperationId = 0;
 		try {
 			if (Preference.getBoolean(context, context.getResources().getString(R.string.shared_pref_reboot_done))) {
 				if (replyPayload == null) {
@@ -198,6 +196,8 @@ public class MessageProcessor implements APIResultCallBack {
 				Preference.removePreference(context, context.getResources().getString(R.string.shared_pref_reboot_op_id));
 			}
 			if (replyPayload != null) {
+				isUpgradeTriggered = false;
+				List<org.wso2.emm.agent.beans.Operation> replyOperations = new ArrayList<>();
 				for (org.wso2.emm.agent.beans.Operation operation : replyPayload) {
 					if (operation == null) {
 						continue;
@@ -210,67 +210,57 @@ public class MessageProcessor implements APIResultCallBack {
 						operation.setStatus(context.getResources().getString(R.string.operation_value_progress));
 						isRebootTriggered = true;
 					} else if (Constants.Operation.UPGRADE_FIRMWARE.equals(operation.getCode())) {
-                        if ((!COMPLETE_STATE.equals(operation.getStatus()) && !ERROR_STATE.equals(operation.getStatus
-                                ()))) {
-							//All the IN_PROGRESS state firmware operations should will come into this block
-							int opId = Preference.getInt(context, "firmwareOperationId");
-							int erroneousId = Preference.getInt(context, "LastErroneousFirmwareOperationId");
-							if (Constants.DEBUG_MODE_ENABLED) {
-								Log.d(TAG, "operation status at the moment is " + operation.getStatus());
-                                Log.d(TAG, "Received Operation Id : " + operation.getId());
-                                Log.d(TAG, "Current Operation Id : " + Preference.getInt(context,
-                                        "firmwareOperationId"));
-                                Log.d(TAG, "Last operation Id with ERROR state : " + Preference.getInt(context,
-                                        "LastErroneousFirmwareOperationId"));
+						//All the IN_PROGRESS state firmware operations should will come into this block
+						int opId = Preference.getInt(context, "firmwareOperationId");
+						if (Constants.DEBUG_MODE_ENABLED) {
+							Log.d(TAG, "Ongoing Operation Id : " + opId);
+							Log.d(TAG, "Received Operation status: " + operation.getStatus());
+							Log.d(TAG, "Received Operation Id : " + operation.getId());
+						}
+						//Initially when the operation status is In Progress, 'isUpgradeTriggered'
+						// is set to 'true' to call the system app. After initial call, to prevent
+						// calling system app again and again for the same operation Id following
+						// checks are added.
+						boolean hasUpgrade = false;
+						if (opId == operation.getId()) {
+							Log.w(TAG, "Ignoring duplicate firmware upgrade operation: " + opId);
+						} else if (opId == 0) {
+							hasUpgrade = true;
+						} else if (operation.getId() != 0 && operation.getId() != opId) {
+							long previousUpgradeInitiatedAt = Preference.getLong(context,
+									Constants.PreferenceFlag.FIRMWARE_UPGRADE_INITIATED_AT);
+							currentTime = System.currentTimeMillis();
+							if (previousUpgradeInitiatedAt < currentTime && previousUpgradeInitiatedAt
+									+ Constants.FIRMWARE_DOWNLOAD_OPERATION_TIMEOUT > currentTime) {
+								// Set currently received firmware upgrade status to ERROR.
+								operation.setStatus(ERROR_STATE);
+								operation.setOperationResponse("There is an already ongoing firmware " +
+										"upgrade operation with id " + opId);
+								Log.e(TAG, "Firmware upgrade operation '" + operation.getId()
+										+ "' failed. " + operation.getOperationResponse());
+							} else {
+								hasUpgrade = true;
+								// Set previously staled firmware upgrade status to ERROR.
+								org.wso2.emm.agent.beans.Operation firmwareOperation
+										= new org.wso2.emm.agent.beans.Operation();
+								firmwareOperation.setCode(Constants.Operation.UPGRADE_FIRMWARE);
+								firmwareOperation.setStatus(ERROR_STATE);
+								firmwareOperation.setId(opId);
+								firmwareOperation.setOperationResponse("Operation timed out.");
+								replyOperations.add(firmwareOperation);
+								Log.e(TAG, "Firmware upgrade operation '" + firmwareOperation.getId()
+										+ "' failed. " + firmwareOperation.getOperationResponse());
 							}
-                            //Initially when the operation status is In Progress, 'isUpgradeTriggered'
-                            // is set to 'true' to call the system app. After initial call, to prevent
-                            // calling system app again and again for the same operation Id following
-                            // checks are added.
-							if(erroneousId!= 0 && operation.getId() == erroneousId){
-								isUpgradeTriggered = false;
-							} else if (opId == operation.getId()){
-								if (Constants.DEBUG_MODE_ENABLED) {
-									Log.d(TAG, "isUpgradeTriggered is set to false");
-								}
-								isUpgradeTriggered = false;
-							} else if (opId == 0) {
-								Preference.putInt(context, "firmwareOperationId", operation.getId());
-								Preference.putLong(context,
-										Constants.PreferenceFlag.FIRMWARE_UPGRADE_INITIATED_AT,
-										System.currentTimeMillis());
-								isUpgradeTriggered = true;
-							} else if (operation.getId() != 0 && operation.getId() != opId){
-								long previousUpgradeInitiatedAt = Preference.getLong(context,
-										Constants.PreferenceFlag.FIRMWARE_UPGRADE_INITIATED_AT);
-								currentTime = System.currentTimeMillis();
-								if (previousUpgradeInitiatedAt < currentTime && previousUpgradeInitiatedAt
-										+ Constants.FIRMWARE_DOWNLOAD_OPERATION_TIMEOUT > currentTime) {
-									Log.e(TAG, "This is a new Firmware upgrade operation but one operation " +
-											"is still on going");
-									queuedFirmwareOperationlist.add(operation.getId());
-								} else {
-									Preference.putInt(context, "firmwareOperationId", operation.getId());
-									Preference.putLong(context,
-											Constants.PreferenceFlag.FIRMWARE_UPGRADE_INITIATED_AT,
-											System.currentTimeMillis());
-									org.wso2.emm.agent.beans.Operation firmwareOperation
-											= new org.wso2.emm.agent.beans.Operation();
-									firmwareOperation.setId(opId);
-									firmwareOperation.setCode(Constants.Operation.UPGRADE_FIRMWARE);
-									firmwareOperation.setStatus(ERROR_STATE);
-									firmwareOperation.setOperationResponse("Operation timed out.");
-									if (replyPayload != null) {
-										replyPayload.add(firmwareOperation);
-									} else {
-										replyPayload = new ArrayList<>();
-										replyPayload.add(firmwareOperation);
-									}
-									isUpgradeTriggered = true;
-								}
-							}
-                            //Operation Id of the received reply payload is stored
-                            firmwareUpgradeOperationId = operation.getId();
+						}
+						if (hasUpgrade) {
+							isUpgradeTriggered = true;
+							Preference.putInt(context, "firmwareOperationId", operation.getId());
+							Preference.putLong(context,
+									Constants.PreferenceFlag.FIRMWARE_UPGRADE_INITIATED_AT,
+									System.currentTimeMillis());
+						}
+						if (Constants.DEBUG_MODE_ENABLED) {
+							Log.d(TAG, "isUpgradeTriggered is set to: " + isUpgradeTriggered);
 						}
 					} else if (Constants.Operation.EXECUTE_SHELL_COMMAND.equals(operation.getCode()) && !ERROR_STATE
                             .equals(operation.getStatus())){
@@ -283,52 +273,12 @@ public class MessageProcessor implements APIResultCallBack {
 						}
 					}
 				}
-			}
-
-			if(ERROR_STATE.equals(Preference.getString(context, context.getResources().getString(
-					R.string.firmware_upgrade_response_status)))){
-                if (Constants.DEBUG_MODE_ENABLED) {
-                    Log.d(TAG, "Firmware operation state is ERROR");
-                }
-				Preference.putInt(context, "LastErroneousFirmwareOperationId", Preference.getInt(context,
-						"firmwareOperationId"));
-				Preference.putInt(context, "firmwareOperationId", 0);
-				isUpgradeTriggered = false;
-			}
-
-			if (COMPLETE_STATE.equals(Preference.getString(context, context.getResources().getString(R.string
-					.firmware_upgrade_response_status)))) {
-                if (Constants.DEBUG_MODE_ENABLED) {
-                    Log.d(TAG, "Firmware operation state is SUCCESSFUL");
-                }
-				Preference.putInt(context, "firmwareOperationId", 0);
-				isUpgradeTriggered = false;
-			}
-
-			if (!queuedFirmwareOperationlist.isEmpty()){
-				for (int queuedOperationId : queuedFirmwareOperationlist) {
-					org.wso2.emm.agent.beans.Operation firmwareOperation = new org.wso2.emm.agent.beans.Operation();
-					firmwareOperation.setId(queuedOperationId);
-					firmwareOperation.setCode(Constants.Operation.UPGRADE_FIRMWARE);
-					firmwareOperation.setStatus(ERROR_STATE);
-					firmwareOperation.setOperationResponse("There is an already running firmware upgrade operation");
-					if (replyPayload != null) {
-						replyPayload.add(firmwareOperation);
-					} else {
-						replyPayload = new ArrayList<>();
-						replyPayload.add(firmwareOperation);
-					}
-				}
-				queuedFirmwareOperationlist = new ArrayList<>();
+				replyPayload.addAll(replyOperations);
 			}
 
 			int firmwareOperationId = Preference.getInt(context, context.getResources().getString(
 					R.string.firmware_upgrade_response_id));
-
 			if (firmwareOperationId != 0) {
-				//If there's a firmwareResponseId that means the operation is already triggered.
-				// Therefore cleaning the operation Id set above
-				firmwareUpgradeOperationId = 0;
 				org.wso2.emm.agent.beans.Operation firmwareOperation = new org.wso2.emm.agent.beans.Operation();
 				firmwareOperation.setId(firmwareOperationId);
 				firmwareOperation.setCode(Constants.Operation.UPGRADE_FIRMWARE);
@@ -353,17 +303,17 @@ public class MessageProcessor implements APIResultCallBack {
 					replyPayload = new ArrayList<>();
 					replyPayload.add(firmwareOperation);
 				}
+				int opId = Preference.getInt(context, "firmwareOperationId");
+				if (firmwareOperationId == opId && !IN_PROGRESS_STATE.equals(firmwareOperation.getStatus())) {
+					// Only clear firmwareOperationId if operation comes to finite state.
+					Preference.putInt(context, "firmwareOperationId", 0);
+				}
 				Preference.putInt(context, context.getResources().getString(
 						R.string.firmware_upgrade_response_id), 0);
 				Preference.putString(context, context.getResources().getString(
 						R.string.firmware_upgrade_response_status), null);
 				Preference.putString(context, context.getResources().getString(
 						R.string.firmware_upgrade_response_message), null);
-			}
-
-			//if there's no new firmware upgrade operation this will prevent calling system app
-			if (firmwareUpgradeOperationId == 0){
-				isUpgradeTriggered = false;
 			}
 
 			appUninstallOperationId = Preference.getInt(context, context.getResources()


### PR DESCRIPTION
## Purpose
> Agent handling firmware upgrade operations incorrectly whenever shared pref exists with firmware upgrade failure status. This is fixing that issue.

## Goals
> Fixed operation staling issue in firmware upgrade

## Approach
> Update firmware upgrade operation handling logic

## User stories
> N/A

## Release note
> Fixed operation staling issue in firmware upgrade

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Android 23
 
## Learning
> N/A