### PR TITLE
Fixing https://github.com/wso2/product-iots/issues/1866

### DIFF
--- a/client/client/build.gradle
+++ b/client/client/build.gradle
@@ -177,6 +177,8 @@ android {
             buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "false"
             //Collect WiFi scan results
             buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
+            //Is user consent required for file upload from device to server
+            buildConfigField "boolean", "REQUIRE_CONSENT_FOR_FILE_UPLOAD", "true"
         }
         staging {
             // DEBUG_MODE_ENABLED: Make the agent print the debug logs.
@@ -306,6 +308,8 @@ android {
             buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "false"
             //Collect WiFi scan results
             buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
+            //Is user consent required for file upload from device to server
+            buildConfigField "boolean", "REQUIRE_CONSENT_FOR_FILE_UPLOAD", "true"
             debuggable true
         }
         debugCope {
@@ -438,6 +442,8 @@ android {
             buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "false"
             //Collect WiFi scan results
             buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "true"
+            //Is user consent required for file upload from device to server
+            buildConfigField "boolean", "REQUIRE_CONSENT_FOR_FILE_UPLOAD", "true"
             debuggable true
             signingConfig signingConfigs.debug
         }
@@ -571,6 +577,8 @@ android {
             buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "true"
             //Collect WiFi scan results
             buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
+            //Is user consent required for file upload from device to server
+            buildConfigField "boolean", "REQUIRE_CONSENT_FOR_FILE_UPLOAD", "true"
         }
         debug {
             // DEBUG_MODE_ENABLED: Make the agent print the debug logs.
@@ -702,6 +710,8 @@ android {
             buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "true"
             //Collect WiFi scan results
             buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
+            //Is user consent required for file upload from device to server
+            buildConfigField "boolean", "REQUIRE_CONSENT_FOR_FILE_UPLOAD", "true"
         }
     }
     compileOptions {

--- a/client/client/src/main/java/org/wso2/iot/agent/services/MessageProcessor.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/MessageProcessor.java
@@ -520,6 +520,9 @@ public class MessageProcessor implements APIResultCallBack {
                 fileUpload.setOperationResponse(prefs.getString(resources.getString(R.string.
                         FILE_UPLOAD_RESPONSE), resources.getString(R.string.operation_value_error)));
                 fileUpload.setEnabled(true);
+                if (replyPayload == null) {
+                    replyPayload = new ArrayList<>();
+                }
                 replyPayload.add(fileUpload);
                 SharedPreferences.Editor editor = prefs.edit();
                 editor.remove(resources.getString(R.string.FILE_UPLOAD_ID));
@@ -536,6 +539,9 @@ public class MessageProcessor implements APIResultCallBack {
                 fileDownload.setOperationResponse(prefs.getString(resources.getString(R.string.
                         FILE_DOWNLOAD_RESPONSE), resources.getString(R.string.operation_value_error)));
                 fileDownload.setEnabled(true);
+                if (replyPayload == null) {
+                    replyPayload = new ArrayList<>();
+                }
                 replyPayload.add(fileDownload);
                 SharedPreferences
                         .Editor editor = prefs.edit();

--- a/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManagerBYOD.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManagerBYOD.java
@@ -88,30 +88,33 @@ public class OperationManagerBYOD extends OperationManager {
                 Intent uploadIntent = new Intent(context, FileUploadReceiver.class);
                 uploadIntent.putExtra(getContextResources().getString(R.string.intent_extra_operation_object), operation);
 
-                PendingIntent requestPermission = PendingIntent.getBroadcast(context, 0, uploadIntent,
-                        PendingIntent.FLAG_CANCEL_CURRENT);
+                if (Constants.REQUIRE_CONSENT_FOR_FILE_UPLOAD) {
+                    PendingIntent requestPermission = PendingIntent.getBroadcast(context, 0, uploadIntent,
+                            PendingIntent.FLAG_CANCEL_CURRENT);
 
-                Intent cancelIntent = new Intent(context, FileUploadCancelReceiver.class);
-                cancelIntent.putExtra(getContextResources().getString(R.string.intent_extra_operation_object), operation);
+                    Intent cancelIntent = new Intent(context, FileUploadCancelReceiver.class);
+                    cancelIntent.putExtra(getContextResources().getString(R.string.intent_extra_operation_object), operation);
 
-                PendingIntent cancel = PendingIntent.getBroadcast(context, 0, cancelIntent,
-                        PendingIntent.FLAG_CANCEL_CURRENT);
+                    PendingIntent cancel = PendingIntent.getBroadcast(context, 0, cancelIntent,
+                            PendingIntent.FLAG_CANCEL_CURRENT);
+                    NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context);
+                    mBuilder
+                            .setSmallIcon(android.R.drawable.ic_menu_upload)
+                            .setContentTitle(selectedFile.getName() + getContextResources().getString(R.
+                                    string.NOTIFICATION_TITLE))
+                            .setTicker(getContextResources().getString(R.
+                                    string.NOTIFICATION_TICKER))
+                            .setAutoCancel(true)
+                            .addAction(android.R.drawable.ic_menu_upload, getContextResources().getString(R.
+                                    string.NOTIFICATION_ALLOW), requestPermission)
+                            .addAction(android.R.drawable.ic_menu_close_clear_cancel, getContextResources().
+                                    getString(R.string.NOTIFICATION_CANCEL), cancel);
 
-                NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context);
-                mBuilder
-                        .setSmallIcon(android.R.drawable.ic_menu_upload)
-                        .setContentTitle(selectedFile.getName() + getContextResources().getString(R.
-                                string.NOTIFICATION_TITLE))
-                        .setTicker(getContextResources().getString(R.
-                                string.NOTIFICATION_TICKER))
-                        .setAutoCancel(true)
-                        .addAction(android.R.drawable.ic_menu_upload, getContextResources().getString(R.
-                                string.NOTIFICATION_ALLOW), requestPermission)
-                        .addAction(android.R.drawable.ic_menu_close_clear_cancel, getContextResources().
-                                getString(R.string.NOTIFICATION_CANCEL), cancel);
-
-                NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-                manager.notify(operation.getId(), mBuilder.build());
+                    NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                    manager.notify(operation.getId(), mBuilder.build());
+                } else {
+                    context.sendBroadcast(uploadIntent);
+                }
             } else {
                 operation.setStatus(getContextResources().getString(R.string.
                         operation_value_error));

--- a/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManagerOlderSdk.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManagerOlderSdk.java
@@ -116,31 +116,35 @@ public class OperationManagerOlderSdk extends OperationManager {
                 Context context = getContext();
                 Intent uploadIntent = new Intent(context, FileUploadReceiver.class);
                 uploadIntent.putExtra(getContextResources().getString(R.string.intent_extra_operation_object), operation);
+                if (Constants.REQUIRE_CONSENT_FOR_FILE_UPLOAD) {
+                    context.sendBroadcast(uploadIntent);
+                    PendingIntent requestPermission = PendingIntent.getBroadcast(context, 0, uploadIntent,
+                            PendingIntent.FLAG_CANCEL_CURRENT);
 
-                PendingIntent requestPermission = PendingIntent.getBroadcast(context, 0, uploadIntent,
-                        PendingIntent.FLAG_CANCEL_CURRENT);
+                    Intent cancelIntent = new Intent(context, FileUploadCancelReceiver.class);
+                    cancelIntent.putExtra(getContextResources().getString(R.string.intent_extra_operation_object), operation);
 
-                Intent cancelIntent = new Intent(context, FileUploadCancelReceiver.class);
-                cancelIntent.putExtra(getContextResources().getString(R.string.intent_extra_operation_object), operation);
+                    PendingIntent cancel = PendingIntent.getBroadcast(context, 0, cancelIntent,
+                            PendingIntent.FLAG_CANCEL_CURRENT);
 
-                PendingIntent cancel = PendingIntent.getBroadcast(context, 0, cancelIntent,
-                        PendingIntent.FLAG_CANCEL_CURRENT);
+                    NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context);
+                    mBuilder
+                            .setSmallIcon(android.R.drawable.ic_menu_upload)
+                            .setContentTitle(selectedFile.getName() + getContextResources().getString(R.
+                                    string.NOTIFICATION_TITLE))
+                            .setTicker(getContextResources().getString(R.
+                                    string.NOTIFICATION_TICKER))
+                            .setAutoCancel(true)
+                            .addAction(android.R.drawable.ic_menu_upload, getContextResources().getString(R.
+                                    string.NOTIFICATION_ALLOW), requestPermission)
+                            .addAction(android.R.drawable.ic_menu_close_clear_cancel, getContextResources().
+                                    getString(R.string.NOTIFICATION_CANCEL), cancel);
 
-                NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context);
-                mBuilder
-                        .setSmallIcon(android.R.drawable.ic_menu_upload)
-                        .setContentTitle(selectedFile.getName() + getContextResources().getString(R.
-                                string.NOTIFICATION_TITLE))
-                        .setTicker(getContextResources().getString(R.
-                                string.NOTIFICATION_TICKER))
-                        .setAutoCancel(true)
-                        .addAction(android.R.drawable.ic_menu_upload, getContextResources().getString(R.
-                                string.NOTIFICATION_ALLOW), requestPermission)
-                        .addAction(android.R.drawable.ic_menu_close_clear_cancel, getContextResources().
-                                getString(R.string.NOTIFICATION_CANCEL), cancel);
-
-                NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-                manager.notify(operation.getId(), mBuilder.build());
+                    NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                    manager.notify(operation.getId(), mBuilder.build());
+                } else {
+                    context.sendBroadcast(uploadIntent);
+                }
             } else {
                 operation.setStatus(getContextResources().getString(R.string.
                         operation_value_error));

--- a/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
@@ -77,6 +77,8 @@ public class Constants {
 	public static final int APP_UNINSTALL_TIMEOUT = 10 * 60 * 1000;
 	//Should be grater than FIRMWARE_DOWNLOAD_TIMEOUT in the system service.
 	public static final int FIRMWARE_DOWNLOAD_OPERATION_TIMEOUT = 6 * 60 * 1000;
+	//Is user consent required for file upload from device to server
+	public static final boolean REQUIRE_CONSENT_FOR_FILE_UPLOAD = BuildConfig.REQUIRE_CONSENT_FOR_FILE_UPLOAD;
 
 	// This is used to skip the license
 	public static final boolean SKIP_LICENSE = BuildConfig.SKIP_LICENSE;


### PR DESCRIPTION
 Make the user consent for file upload configurable and fix the issue of reply payload not initialized when only  file upload operation is processed.

## Purpose
 Make the user consent for file upload configurable and fix the issue of reply payload not initialized when only  file upload operation is processed.

## Goals
 Make the user consent for file upload configurable and fix the issue of reply payload not initialized when only  file upload operation is processed.

## Approach
 Make the user consent for file upload configurable and fix the issue of reply payload not initialized when only  file upload operation is processed.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A