### PR TITLE
Make remote control feature mutual ssl compatible 

### DIFF
--- a/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManager.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManager.java
@@ -1161,10 +1161,11 @@ public abstract class OperationManager implements APIResultCallBack, VersionBase
             if (operation.getPayLoad() != null) {
                 JSONObject payload = new JSONObject(operation.getPayLoad().toString());
                 Object serverUrl = payload.get("serverUrl");
-                if (serverUrl != null) {
+                Object uuidToValidateDevice = payload.get("uuidToValidateDevice");
+                if (serverUrl != null && uuidToValidateDevice != null) {
                     // Initialize web socket session
                     WebSocketSessionHandler.getInstance(context).initializeSession(serverUrl.toString(),
-                            operation.getId());
+                            operation.getId(), uuidToValidateDevice.toString());
                     operation.setStatus(resources.getString(R.string.operation_value_completed));
 
                 } else {

--- a/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManager.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManager.java
@@ -1162,12 +1162,17 @@ public abstract class OperationManager implements APIResultCallBack, VersionBase
                 JSONObject payload = new JSONObject(operation.getPayLoad().toString());
                 Object serverUrl = payload.get("serverUrl");
                 Object uuidToValidateDevice = payload.get("uuidToValidateDevice");
-                if (serverUrl != null && uuidToValidateDevice != null) {
-                    // Initialize web socket session
-                    WebSocketSessionHandler.getInstance(context).initializeSession(serverUrl.toString(),
-                            operation.getId(), uuidToValidateDevice.toString());
-                    operation.setStatus(resources.getString(R.string.operation_value_completed));
-
+                if (serverUrl != null) {
+                    if(uuidToValidateDevice != null) {
+                        // Initialize web socket session
+                        WebSocketSessionHandler.getInstance(context).initializeSession(serverUrl.toString(),
+                                operation.getId(), uuidToValidateDevice.toString());
+                        operation.setStatus(resources.getString(R.string.operation_value_completed));
+                    } else {
+                        operation.setStatus(resources.getString(R.string.operation_value_error));
+                        operation.setOperationResponse("UUID cannot be found in the operation " +
+                                "payload");
+                    }
                 } else {
                     operation.setStatus(resources.getString(R.string.operation_value_error));
                     operation.setOperationResponse("Server url cannot be found");

--- a/client/client/src/main/java/org/wso2/iot/agent/transport/websocket/WebSocketSessionHandler.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/transport/websocket/WebSocketSessionHandler.java
@@ -91,13 +91,13 @@ public class WebSocketSessionHandler {
      * @param operationId operation id for initialized session
      * @throws TransportHandlerException throws when error occur with web socket session
      */
-    public void initializeSession(String serverURL, int operationId) throws TransportHandlerException {
+    public void initializeSession(String serverURL, int operationId, String uuidToValidateDevice)
+            throws TransportHandlerException {
         if (this.operationId == operationId) {
             Log.w(TAG, "operation id : " + operationId + " is already connected");
             return;
         }
         DeviceInfo deviceInfo = new DeviceInfo(context);
-        String accessToken = Preference.getString(context, "access_token");
         if (serverURL.contains("localhost")) {
             ServerConfig serverConfig = new ServerConfig();
             serverURL = serverURL.replace("localhost", serverConfig.getHostFromPreferences(context));
@@ -111,7 +111,7 @@ public class WebSocketSessionHandler {
         }
         URI uri;
         String remoteEndpoint = serverURL + Constants.REMOTE_SESSION_DEVICE_ENDPOINT_CONTEXT + "/" +
-                deviceInfo.getDeviceId() + "/" + operationId + "?websocketToken=" + accessToken;
+                deviceInfo.getDeviceId() + "/" + operationId + "?websocketToken=" + uuidToValidateDevice;
         try {
             uri = new URI(remoteEndpoint);
             Log.i(TAG, "web socket session connected for operation id:" + operationId);


### PR DESCRIPTION
## Purpose
> When an Android device is enrolled to IoT server using mutual-ssl remote session creation fails. Device screen sharer, adb command executer and to Logcat viewer aren't working. This PR will address this issue. Resolves https://github.com/wso2/cdmf-agent-android/issues/186

## Goals
> To enable remote control feature when an Android device is enrolled using mutual-ssl.

## Approach
> Previously this operation logic was handled via the access tokens. Hence, in a situation where the device is enrolled under mutual-ssl, there won't be any access tokens to establish the socket connection as per the previous logic. With this change there is a new UUID introduced instead of the access token. UUID will be initially generated by the server and sent to the securely enrolled device. And then the device will call back to the server with this UUID to establish the web-socket connection. 

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> IoT Server v3.3.1
 
## Learning
> N/A