### PR TITLE
Fix remote control feature to work with OAuth authenticator

### DIFF
--- a/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManager.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/operation/OperationManager.java
@@ -1164,15 +1164,24 @@ public abstract class OperationManager implements APIResultCallBack, VersionBase
                 Object serverUrl = payload.get("serverUrl");
                 Object uuidToValidateDevice = payload.get("uuidToValidateDevice");
                 if (serverUrl != null) {
-                    if(uuidToValidateDevice != null) {
-                        // Initialize web socket session
-                        WebSocketSessionHandler.getInstance(context).initializeSession(serverUrl.toString(),
-                                operation.getId(), uuidToValidateDevice.toString());
-                        operation.setStatus(resources.getString(R.string.operation_value_completed));
+                    if (org.wso2.iot.agent.proxy.utils.Constants.Authenticator.AUTHENTICATOR_IN_USE.
+                            equals(org.wso2.iot.agent.proxy.utils.Constants.Authenticator.
+                                    MUTUAL_SSL_AUTHENTICATOR)) {
+                        if (uuidToValidateDevice != null) {
+                            // Initialize web socket session when AUTHENTICATOR_IN_USE is MUTUAL_SSL_AUTHENTICATOR
+                            WebSocketSessionHandler.getInstance(context).initializeSession(serverUrl.toString(),
+                                    operation.getId(), uuidToValidateDevice.toString());
+                            operation.setStatus(resources.getString(R.string.operation_value_completed));
+                        } else {
+                            operation.setStatus(resources.getString(R.string.operation_value_error));
+                            operation.setOperationResponse("UUID cannot be found in the operation " +
+                                    "payload");
+                        }
                     } else {
-                        operation.setStatus(resources.getString(R.string.operation_value_error));
-                        operation.setOperationResponse("UUID cannot be found in the operation " +
-                                "payload");
+                        // Initialize web socket session when AUTHENTICATOR_IN_USE is OAUTH_AUTHENTICATOR
+                        WebSocketSessionHandler.getInstance(context).initializeSession(serverUrl.toString(),
+                                operation.getId(), null);
+                        operation.setStatus(resources.getString(R.string.operation_value_completed));
                     }
                 } else {
                     operation.setStatus(resources.getString(R.string.operation_value_error));

--- a/client/client/src/main/java/org/wso2/iot/agent/transport/websocket/WebSocketSessionHandler.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/transport/websocket/WebSocketSessionHandler.java
@@ -110,8 +110,19 @@ public class WebSocketSessionHandler {
             }
         }
         URI uri;
+        String token = null;
+        if(uuidToValidateDevice != null){
+            token = uuidToValidateDevice;
+        } else {
+            String access_token = Preference.getString(context, "access_token");
+            if(access_token != null){
+                token = access_token;
+            } else {
+                Log.e(TAG, "Could not extract the access token");
+            }
+        }
         String remoteEndpoint = serverURL + Constants.REMOTE_SESSION_DEVICE_ENDPOINT_CONTEXT + "/" +
-                deviceInfo.getDeviceId() + "/" + operationId + "?websocketToken=" + uuidToValidateDevice;
+                deviceInfo.getDeviceId() + "/" + operationId + "?websocketToken=" + token;
         try {
             uri = new URI(remoteEndpoint);
             Log.i(TAG, "web socket session connected for operation id:" + operationId);


### PR DESCRIPTION
## Purpose
> Fix remote control feature to work with OAuth authenticator

## Goals
> Fix remote control feature to work with OAuth authenticator

## Approach
> Separated the operation manager flow for OAuth authenticator and Mutual SSL authenticator

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> IoT Server v3.3.1
 
## Learning
> N/A