### PR TITLE
Reducing DEVICE_INFO payload size by avoiding unchanged properties.

### DIFF
--- a/client/client/build.gradle
+++ b/client/client/build.gradle
@@ -176,7 +176,7 @@ android {
             //Publish location changes to server
             buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "false"
             //Collect WiFi scan results
-            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
+            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "true"
             //Is user consent required for file upload from device to server
             buildConfigField "boolean", "REQUIRE_CONSENT_FOR_FILE_UPLOAD", "true"
         }
@@ -307,7 +307,7 @@ android {
             //Publish location changes to server
             buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "false"
             //Collect WiFi scan results
-            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
+            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "true"
             //Is user consent required for file upload from device to server
             buildConfigField "boolean", "REQUIRE_CONSENT_FOR_FILE_UPLOAD", "true"
             debuggable true
@@ -576,7 +576,7 @@ android {
             //Publish location changes to server
             buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "true"
             //Collect WiFi scan results
-            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
+            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "true"
             //Is user consent required for file upload from device to server
             buildConfigField "boolean", "REQUIRE_CONSENT_FOR_FILE_UPLOAD", "true"
         }
@@ -709,7 +709,7 @@ android {
             //Publish location changes to server
             buildConfigField "boolean", "LOCATION_PUBLISHING_ENABLED", "true"
             //Collect WiFi scan results
-            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "false"
+            buildConfigField "boolean", "WIFI_SCANNING_ENABLED", "true"
             //Is user consent required for file upload from device to server
             buildConfigField "boolean", "REQUIRE_CONSENT_FOR_FILE_UPLOAD", "true"
         }

--- a/client/client/src/main/java/org/wso2/iot/agent/beans/Device.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/beans/Device.java
@@ -17,6 +17,8 @@
 
 package org.wso2.iot.agent.beans;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import org.wso2.iot.agent.AndroidAgentException;
 import org.wso2.iot.agent.utils.CommonUtils;
 
@@ -26,6 +28,7 @@ import java.util.List;
  * This class represents the basic information of
  * the carbon-device-mgt supported device
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Device {
 
 	private String description;

--- a/client/client/src/main/java/org/wso2/iot/agent/services/AgentStartupReceiver.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/AgentStartupReceiver.java
@@ -107,6 +107,10 @@ public class AgentStartupReceiver extends BroadcastReceiver {
             Preference.putString(context, Constants.LAST_WIFI_SCAN_RESULT_SHARED_PREF,null);
         }
 
+        if(Preference.getString(context, Constants.LAST_APP_LIST_SHARED_PREF) != null) {
+            Preference.putString(context, Constants.LAST_APP_LIST_SHARED_PREF,null);
+        }
+
         if (Intent.ACTION_BOOT_COMPLETED.equals(action) || Constants.AGENT_UPDATED_BROADCAST_ACTION.equals(action)) {
             if (Constants.OWNERSHIP_COSU.equals(Constants.DEFAULT_OWNERSHIP)) {
                 Preference.putBoolean(context.getApplicationContext(), Constants.AGENT_FRESH_START, true);

--- a/client/client/src/main/java/org/wso2/iot/agent/services/AgentStartupReceiver.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/AgentStartupReceiver.java
@@ -95,6 +95,18 @@ public class AgentStartupReceiver extends BroadcastReceiver {
             LocalNotification.startPolling(context);
         }
 
+        /**
+         * Clear the device info and wifi info payloads stored in shared preference
+         * when the device restarts.
+         */
+        if(Preference.getString(context, Constants.LAST_DEVICE_INFO_SHARED_PREF) != null) {
+            Preference.putString(context, Constants.LAST_DEVICE_INFO_SHARED_PREF,null);
+        }
+
+        if(Preference.getString(context, Constants.LAST_WIFI_SCAN_RESULT_SHARED_PREF) != null) {
+            Preference.putString(context, Constants.LAST_WIFI_SCAN_RESULT_SHARED_PREF,null);
+        }
+
         if (Intent.ACTION_BOOT_COMPLETED.equals(action) || Constants.AGENT_UPDATED_BROADCAST_ACTION.equals(action)) {
             if (Constants.OWNERSHIP_COSU.equals(Constants.DEFAULT_OWNERSHIP)) {
                 Preference.putBoolean(context.getApplicationContext(), Constants.AGENT_FRESH_START, true);

--- a/client/client/src/main/java/org/wso2/iot/agent/services/DeviceInfoPayload.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/DeviceInfoPayload.java
@@ -137,6 +137,7 @@ public class DeviceInfoPayload {
         if (device == null) {
             device = new Device();
         }
+
         deviceInfo = new DeviceInfo(context);
         Power power = phoneState.getBatteryDetails();
         if ((keyValPair.get(Constants.Device.DEVICE_IDENTIFIER) == null) ||
@@ -230,15 +231,6 @@ public class DeviceInfoPayload {
             property.setValue(deviceInfo.getOSBuildDate());
             properties.add(property);
             keyValPair.put(Constants.Device.OS_BUILD_DATE, deviceInfo.getOSBuildDate().toString());
-        }
-
-        if ((keyValPair.get(Constants.Device.NAME) == null)
-                || !keyValPair.get(Constants.Device.NAME).toString().equals(deviceInfo.getDeviceName().toString())) {
-            property = new Device.Property();
-            property.setName(Constants.Device.NAME);
-            property.setValue(deviceInfo.getDeviceName());
-            properties.add(property);
-            keyValPair.put(Constants.Device.NAME, deviceInfo.getDeviceName().toString());
         }
 
         if (deviceLocation != null) {

--- a/client/client/src/main/java/org/wso2/iot/agent/services/DeviceInfoPayload.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/DeviceInfoPayload.java
@@ -109,8 +109,8 @@ public class DeviceInfoPayload {
     private void getInfo() throws AndroidAgentException {
 
         HashMap<String, String> keyValPair = null;
-        if (Preference.getString(context, "lastDeviceObject") != null) {
-            String lastUpdatedInfoString = Preference.getString(context, "lastDeviceObject");
+        if (Preference.getString(context, Constants.LAST_DEVICE_INFO_SHARED_PREF) != null) {
+            String lastUpdatedInfoString = Preference.getString(context, Constants.LAST_DEVICE_INFO_SHARED_PREF);
             byte[] lastUpdatedInfoByteArray = Base64.decode(lastUpdatedInfoString, Base64.DEFAULT);
             ByteArrayInputStream bais = new ByteArrayInputStream(lastUpdatedInfoByteArray);
             ObjectInputStream ois = null;
@@ -467,7 +467,7 @@ public class DeviceInfoPayload {
             oos.writeObject(keyValPair);
             String stringObject = null;
             stringObject = Base64.encodeToString(bao.toByteArray(), Base64.DEFAULT);
-            Preference.putString(context, "lastDeviceObject", stringObject);
+            Preference.putString(context, Constants.LAST_DEVICE_INFO_SHARED_PREF, stringObject);
         } catch (IOException e) {
             throw new AndroidAgentException("Error occurred while serializing policy operation object", e);
         }

--- a/client/client/src/main/java/org/wso2/iot/agent/services/DeviceInfoPayload.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/DeviceInfoPayload.java
@@ -125,35 +125,23 @@ public class DeviceInfoPayload {
         } else {
             keyValPair = new HashMap<String, String>();
         }
-
         TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
-
         if (!CommonUtils.isServiceRunning(context, NetworkInfoService.class)) {
             Intent serviceIntent = new Intent(context, NetworkInfoService.class);
             context.startService(serviceIntent);
         }
-
         Location deviceLocation = CommonUtils.getLocation(context);
         if (device == null) {
             device = new Device();
         }
-
         deviceInfo = new DeviceInfo(context);
         Power power = phoneState.getBatteryDetails();
-        if ((keyValPair.get(Constants.Device.DEVICE_IDENTIFIER) == null) ||
-                !keyValPair.get(Constants.Device.DEVICE_IDENTIFIER).toString().equals(deviceInfo.getDeviceId())) {
-            device.setDeviceIdentifier(deviceInfo.getDeviceId());
-            keyValPair.put(Constants.Device.DEVICE_IDENTIFIER, deviceInfo.getDeviceId());
-        }
-        if ((keyValPair.get(Constants.Device.DEVICE_NAME) == null) ||
-                !keyValPair.get(Constants.Device.DEVICE_NAME).toString().equals(deviceInfo.getDeviceName())) {
-            device.setName(deviceInfo.getDeviceName());
-            device.setDescription(deviceInfo.getDeviceName());
-            keyValPair.put(Constants.Device.DEVICE_NAME, deviceInfo.getDeviceName());
-        }
-
+        device.setDeviceIdentifier(deviceInfo.getDeviceId());
+        keyValPair.put(Constants.Device.DEVICE_IDENTIFIER, deviceInfo.getDeviceId());
+        device.setName(deviceInfo.getDeviceName());
+        device.setDescription(deviceInfo.getDeviceName());
+        keyValPair.put(Constants.Device.DEVICE_NAME, deviceInfo.getDeviceName());
         List<Device.Property> properties = new ArrayList<>();
-
         Device.Property property = null;
         if ((keyValPair.get(Constants.Device.SERIAL) == null) ||
                 !keyValPair.get(Constants.Device.SERIAL).toString().equals(deviceInfo.getDeviceSerialNumber())) {
@@ -163,76 +151,68 @@ public class DeviceInfoPayload {
             properties.add(property);
             keyValPair.put(Constants.Device.SERIAL, deviceInfo.getDeviceSerialNumber().toString());
         }
-
         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE)
                 == PackageManager.PERMISSION_GRANTED) {
             if ((keyValPair.get(Constants.Device.IMEI) == null) || !keyValPair.get(Constants.Device.IMEI).toString()
-                    .equals(telephonyManager.getDeviceId().toString())) {
+                    .equals(telephonyManager.getDeviceId())) {
                 property = new Device.Property();
                 property.setName(Constants.Device.IMEI);
                 property.setValue(telephonyManager.getDeviceId());
                 properties.add(property);
-                keyValPair.put(Constants.Device.IMEI, telephonyManager.getDeviceId().toString());
+                keyValPair.put(Constants.Device.IMEI, telephonyManager.getDeviceId());
             }
         }
-
         if ((keyValPair.get(Constants.Device.IMSI) == null) ||
-                !keyValPair.get(Constants.Device.IMSI).toString().equals(deviceInfo.getIMSINumber().toString())) {
+                !keyValPair.get(Constants.Device.IMSI).toString().equals(deviceInfo.getIMSINumber())) {
             property = new Device.Property();
             property.setName(Constants.Device.IMSI);
             property.setValue(deviceInfo.getIMSINumber());
             properties.add(property);
-            keyValPair.put(Constants.Device.IMSI, deviceInfo.getIMSINumber().toString());
+            keyValPair.put(Constants.Device.IMSI, deviceInfo.getIMSINumber());
         }
-
         if ((keyValPair.get(Constants.Device.MAC) == null) ||
                 !keyValPair.get(Constants.Device.MAC).toString().equals(deviceInfo.getMACAddress())) {
             property = new Device.Property();
             property.setName(Constants.Device.MAC);
             property.setValue(deviceInfo.getMACAddress());
             properties.add(property);
-            keyValPair.put(Constants.Device.MAC, deviceInfo.getMACAddress().toString());
+            keyValPair.put(Constants.Device.MAC, deviceInfo.getMACAddress());
         }
-
         if ((keyValPair.get(Constants.Device.MODEL) == null) ||
                 !keyValPair.get(Constants.Device.MODEL).toString()
-                        .equals(deviceInfo.getDeviceModel().toString())) {
+                        .equals(deviceInfo.getDeviceModel())) {
             property = new Device.Property();
             property.setName(Constants.Device.MODEL);
             property.setValue(deviceInfo.getDeviceModel());
             properties.add(property);
-            keyValPair.put(Constants.Device.MODEL, deviceInfo.getDeviceModel().toString());
+            keyValPair.put(Constants.Device.MODEL, deviceInfo.getDeviceModel());
         }
-
         if ((keyValPair.get(Constants.Device.VENDOR) == null) ||
                 !keyValPair.get(Constants.Device.VENDOR).toString()
-                        .equals(deviceInfo.getDeviceManufacturer().toString())) {
+                        .equals(deviceInfo.getDeviceManufacturer())) {
             property = new Device.Property();
             property.setName(Constants.Device.VENDOR);
             property.setValue(deviceInfo.getDeviceManufacturer());
             properties.add(property);
-            keyValPair.put(Constants.Device.VENDOR, deviceInfo.getDeviceManufacturer().toString());
+            keyValPair.put(Constants.Device.VENDOR, deviceInfo.getDeviceManufacturer());
         }
-
         if ((keyValPair.get(Constants.Device.OS) == null)
-                || !keyValPair.get(Constants.Device.OS).toString().equals(deviceInfo.getOsVersion().toString())) {
+                || !keyValPair.get(Constants.Device.OS).toString().equals(deviceInfo.getOsVersion())) {
             property = new Device.Property();
             property.setName(Constants.Device.OS);
             property.setValue(deviceInfo.getOsVersion());
             properties.add(property);
-            keyValPair.put(Constants.Device.OS, deviceInfo.getOsVersion().toString());
+            keyValPair.put(Constants.Device.OS, deviceInfo.getOsVersion());
         }
-
         if ((keyValPair.get(Constants.Device.OS_BUILD_DATE) == null)
                 || !keyValPair.get(Constants.Device.OS_BUILD_DATE).toString()
-                .equals(deviceInfo.getOSBuildDate().toString())) {
+                .equals(deviceInfo.getOSBuildDate())) {
             property = new Device.Property();
             property.setName(Constants.Device.OS_BUILD_DATE);
             property.setValue(deviceInfo.getOSBuildDate());
             properties.add(property);
-            keyValPair.put(Constants.Device.OS_BUILD_DATE, deviceInfo.getOSBuildDate().toString());
+            keyValPair.put(Constants.Device.OS_BUILD_DATE, deviceInfo.getOSBuildDate());
         }
-
         if (deviceLocation != null) {
             double latitude = deviceLocation.getLatitude();
             double longitude = deviceLocation.getLongitude();
@@ -247,7 +227,6 @@ public class DeviceInfoPayload {
                     properties.add(property);
                     keyValPair.put(Constants.Device.MOBILE_DEVICE_LATITUDE, String.valueOf(latitude));
                 }
-
                 if ((keyValPair.get(Constants.Device.MOBILE_DEVICE_LONGITUDE) == null)
                         || !keyValPair.get(Constants.Device.MOBILE_DEVICE_LONGITUDE).toString()
                         .equals(String.valueOf(longitude))) {
@@ -259,7 +238,6 @@ public class DeviceInfoPayload {
                 }
             }
         }
-
         if (registrationId != null) {
             if ((keyValPair.get(Constants.Device.FCM_TOKEN) == null)
                     || !keyValPair.get(Constants.Device.FCM_TOKEN).toString()
@@ -271,9 +249,7 @@ public class DeviceInfoPayload {
                 keyValPair.put(Constants.Device.FCM_TOKEN, registrationId);
             }
         }
-
         List<Device.Property> deviceInfoProperties = new ArrayList<>();
-
         if ((keyValPair.get(Constants.Device.ENCRYPTION_STATUS) == null) || !keyValPair
                 .get(Constants.Device.ENCRYPTION_STATUS).toString()
                 .equals(String.valueOf(deviceInfo.isEncryptionEnabled()))) {
@@ -283,7 +259,6 @@ public class DeviceInfoPayload {
             deviceInfoProperties.add(property);
             keyValPair.put(Constants.Device.ENCRYPTION_STATUS, String.valueOf(deviceInfo.isEncryptionEnabled()));
         }
-
         if ((deviceInfo.getSdkVersion() >= Build.VERSION_CODES.LOLLIPOP)) {
             if ((keyValPair.get(Constants.Device.PASSCODE_STATUS) == null) || !keyValPair
                     .get(Constants.Device.PASSCODE_STATUS).toString()
@@ -295,7 +270,6 @@ public class DeviceInfoPayload {
                 keyValPair.put(Constants.Device.PASSCODE_STATUS, String.valueOf(deviceInfo.isPasscodeEnabled()));
             }
         }
-
         if ((keyValPair.get(Constants.Device.BATTERY_LEVEL) == null) ||
                 !keyValPair.get(Constants.Device.BATTERY_LEVEL).toString()
                         .equals(String.valueOf(Math.round(power.getLevel())))) {
@@ -306,7 +280,6 @@ public class DeviceInfoPayload {
             deviceInfoProperties.add(property);
             keyValPair.put(Constants.Device.BATTERY_LEVEL, String.valueOf(batteryLevel));
         }
-
         if ((keyValPair.get(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL) == null) || !keyValPair
                 .get(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL).toString()
                 .equals(String.valueOf(phoneState.getTotalInternalMemorySize()))) {
@@ -317,7 +290,6 @@ public class DeviceInfoPayload {
             keyValPair.put(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL,
                     String.valueOf(phoneState.getTotalInternalMemorySize()));
         }
-
         if ((keyValPair.get(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE) == null) || !keyValPair
                 .get(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE).toString()
                 .equals(String.valueOf(phoneState.getAvailableInternalMemorySize()))) {
@@ -328,7 +300,6 @@ public class DeviceInfoPayload {
             keyValPair.put(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE,
                     String.valueOf(phoneState.getAvailableInternalMemorySize()));
         }
-
         if ((keyValPair.get(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL) == null) || !keyValPair
                 .get(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL).toString()
                 .equals(String.valueOf(phoneState.getTotalExternalMemorySize()))) {
@@ -339,7 +310,6 @@ public class DeviceInfoPayload {
             keyValPair.put(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL,
                     String.valueOf(phoneState.getTotalExternalMemorySize()));
         }
-
         if ((keyValPair.get(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE) == null) || !keyValPair
                 .get(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE).toString()
                 .equals(String.valueOf(phoneState.getAvailableExternalMemorySize()))) {
@@ -350,7 +320,6 @@ public class DeviceInfoPayload {
             keyValPair.put(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE,
                     String.valueOf(phoneState.getAvailableExternalMemorySize()));
         }
-
         if ((keyValPair.get(Constants.Device.NETWORK_OPERATOR) == null) || !keyValPair
                 .get(Constants.Device.NETWORK_OPERATOR).toString()
                 .equals(String.valueOf(deviceInfo.getNetworkOperatorName()))) {
@@ -366,8 +335,8 @@ public class DeviceInfoPayload {
                 == PackageManager.PERMISSION_GRANTED) {
             String mPhoneNumber = telephonyManager.getLine1Number();
 
-            if ((mPhoneNumber != null) && (keyValPair.get(Constants.Device.PHONE_NUMBER) == null) || !keyValPair
-                    .get(Constants.Device.PHONE_NUMBER).toString().equals(mPhoneNumber)) {
+            if ((mPhoneNumber != null) && ((keyValPair.get(Constants.Device.PHONE_NUMBER) == null) || !keyValPair
+                    .get(Constants.Device.PHONE_NUMBER).toString().equals(mPhoneNumber))) {
                 property = new Device.Property();
                 property.setName(Constants.Device.PHONE_NUMBER);
                 property.setValue(mPhoneNumber);
@@ -375,11 +344,10 @@ public class DeviceInfoPayload {
                 keyValPair.put(Constants.Device.PHONE_NUMBER, mPhoneNumber);
             }
         }
-
         try {
             String network = NetworkInfoService.getNetworkStatus();
-            if ((network != null) && (keyValPair.get(Constants.Device.NETWORK_INFO) == null) || !keyValPair
-                    .get(Constants.Device.NETWORK_INFO).toString().equals(network)) {
+            if ((network != null) && ((keyValPair.get(Constants.Device.NETWORK_INFO) == null) || !keyValPair
+                    .get(Constants.Device.NETWORK_INFO).toString().equals(network))) {
                 property = new Device.Property();
                 property.setName(Constants.Device.NETWORK_INFO);
                 property.setValue(network);
@@ -388,8 +356,8 @@ public class DeviceInfoPayload {
             }
             if (Constants.WIFI_SCANNING_ENABLED) {
                 String wifiScanResult = NetworkInfoService.getWifiScanResult(context);
-                if ((network != null) && (keyValPair.get(Constants.Device.WIFI_SCAN_RESULT) == null) || !keyValPair
-                        .get(Constants.Device.WIFI_SCAN_RESULT).toString().equals(wifiScanResult)) {
+                if ((network != null) && ((keyValPair.get(Constants.Device.WIFI_SCAN_RESULT) == null) || !keyValPair
+                        .get(Constants.Device.WIFI_SCAN_RESULT).toString().equals(wifiScanResult))) {
                     property = new Device.Property();
                     property.setName(Constants.Device.WIFI_SCAN_RESULT);
                     property.setValue(wifiScanResult);
@@ -400,7 +368,6 @@ public class DeviceInfoPayload {
         } catch (AndroidAgentException e) {
             Log.e(TAG, "Error retrieving network status. " + e.getMessage());
         }
-
         RuntimeInfo runtimeInfo = new RuntimeInfo(context);
         String cpuInfoPayload;
         try {
@@ -419,7 +386,6 @@ public class DeviceInfoPayload {
             properties.add(property);
             keyValPair.put(Constants.Device.CPU_INFO, cpuInfoPayload);
         }
-
         String ramInfoPayload;
         try {
             ramInfoPayload = mapper.writeValueAsString(runtimeInfo.getRAMInfo());
@@ -428,7 +394,6 @@ public class DeviceInfoPayload {
             Log.e(TAG, errorMsg, e);
             throw new AndroidAgentException(errorMsg, e);
         }
-
         if ((keyValPair.get(Constants.Device.RAM_INFO) == null) || (keyValPair.get(Constants.Device.RAM_INFO) != null
                 && !keyValPair.get(Constants.Device.RAM_INFO).toString().equals(ramInfoPayload))) {
             property = new Device.Property();
@@ -437,40 +402,31 @@ public class DeviceInfoPayload {
             properties.add(property);
             keyValPair.put(Constants.Device.RAM_INFO, ramInfoPayload);
         }
-
         List<Device.Property> batteryProperties = new ArrayList<>();
         property = new Device.Property();
         property.setName(Constants.Device.BATTERY_LEVEL);
         property.setValue(String.valueOf(power.getLevel()));
         batteryProperties.add(property);
-
         property = new Device.Property();
         property.setName(Constants.Device.SCALE);
         property.setValue(String.valueOf(power.getScale()));
         batteryProperties.add(property);
-
         property = new Device.Property();
         property.setName(Constants.Device.BATTERY_VOLTAGE);
         property.setValue(String.valueOf(power.getVoltage()));
         batteryProperties.add(property);
-
-
         property = new Device.Property();
         property.setName(Constants.Device.HEALTH);
         property.setValue(String.valueOf(power.getHealth()));
         batteryProperties.add(property);
-
         property = new Device.Property();
         property.setName(Constants.Device.STATUS);
         property.setValue(String.valueOf(power.getStatus()));
         batteryProperties.add(property);
-
         property = new Device.Property();
         property.setName(Constants.Device.PLUGGED);
         property.setValue(String.valueOf(power.getPlugged()));
         batteryProperties.add(property);
-
-
         String batteryInfoPayload;
         try {
             batteryInfoPayload = mapper.writeValueAsString(batteryProperties);
@@ -479,7 +435,6 @@ public class DeviceInfoPayload {
             Log.e(TAG, errorMsg, e);
             throw new AndroidAgentException(errorMsg, e);
         }
-
         if ((keyValPair.get(Constants.Device.BATTERY_INFO) == null) ||
                 !keyValPair.get(Constants.Device.BATTERY_INFO).toString().equals(batteryInfoPayload)) {
             property = new Device.Property();
@@ -488,7 +443,6 @@ public class DeviceInfoPayload {
             properties.add(property);
             keyValPair.put(Constants.Device.BATTERY_INFO, batteryInfoPayload);
         }
-
         // building device info json payload
         String deviceInfoPayload;
         try {
@@ -498,7 +452,6 @@ public class DeviceInfoPayload {
             Log.e(TAG, errorMsg, e);
             throw new AndroidAgentException(errorMsg, e);
         }
-
         if ((keyValPair.get(Constants.Device.INFO) == null) || !keyValPair
                 .get(Constants.Device.INFO).toString().equals(deviceInfoPayload)) {
             property = new Device.Property();
@@ -507,7 +460,6 @@ public class DeviceInfoPayload {
             properties.add(property);
             keyValPair.put(Constants.Device.INFO, deviceInfoPayload);
         }
-
         device.setProperties(properties);
         ByteArrayOutputStream bao = new ByteArrayOutputStream();
         try {

--- a/client/client/src/main/java/org/wso2/iot/agent/services/DeviceInfoPayload.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/DeviceInfoPayload.java
@@ -105,7 +105,7 @@ public class DeviceInfoPayload {
      *
      * @throws AndroidAgentException on error
      */
-    @SuppressLint({"HardwareIds", "MissingPermission"})
+    @SuppressLint({"HardwareIds"})
     private void getInfo() throws AndroidAgentException {
 
         HashMap<String, String> keyValPair = null;
@@ -139,27 +139,23 @@ public class DeviceInfoPayload {
         }
         deviceInfo = new DeviceInfo(context);
         Power power = phoneState.getBatteryDetails();
-        if ((keyValPair.get(Constants.Device.DEVICE_IDENTIFIERE) == null) || (keyValPair.get(Constants.Device.DEVICE_IDENTIFIERE.toString()) != null
-                && !keyValPair.get(Constants.Device.DEVICE_IDENTIFIERE).toString().equals(deviceInfo.getDeviceId()))) {
+        if ((keyValPair.get(Constants.Device.DEVICE_IDENTIFIER) == null) ||
+                !keyValPair.get(Constants.Device.DEVICE_IDENTIFIER).toString().equals(deviceInfo.getDeviceId())) {
             device.setDeviceIdentifier(deviceInfo.getDeviceId());
-            keyValPair.put(Constants.Device.DEVICE_IDENTIFIERE, deviceInfo.getDeviceId());
+            keyValPair.put(Constants.Device.DEVICE_IDENTIFIER, deviceInfo.getDeviceId());
         }
-        if ((keyValPair.get(Constants.Device.DEVICE_NAME) == null) || (keyValPair.get(Constants.Device.DEVICE_NAME.toString()) != null
-                && !keyValPair.get(Constants.Device.DEVICE_NAME).toString().equals(deviceInfo.getDeviceName()))) {
-            device.setDescription(deviceInfo.getDeviceName());
-            keyValPair.put(Constants.Device.DEVICE_NAME, deviceInfo.getDeviceName());
-        }
-        if ((keyValPair.get(Constants.Device.DEVICE_NAME) == null) || (keyValPair.get(Constants.Device.DEVICE_NAME.toString()) != null
-                && !keyValPair.get(Constants.Device.DEVICE_NAME).toString().equals(deviceInfo.getDeviceName()))) {
+        if ((keyValPair.get(Constants.Device.DEVICE_NAME) == null) ||
+                !keyValPair.get(Constants.Device.DEVICE_NAME).toString().equals(deviceInfo.getDeviceName())) {
             device.setName(deviceInfo.getDeviceName());
+            device.setDescription(deviceInfo.getDeviceName());
             keyValPair.put(Constants.Device.DEVICE_NAME, deviceInfo.getDeviceName());
         }
 
         List<Device.Property> properties = new ArrayList<>();
 
         Device.Property property = null;
-        if ((keyValPair.get(Constants.Device.SERIAL) == null) || (keyValPair.get(Constants.Device.SERIAL.toString()) != null
-                && !keyValPair.get(Constants.Device.SERIAL).toString().equals(deviceInfo.getDeviceSerialNumber()))) {
+        if ((keyValPair.get(Constants.Device.SERIAL) == null) ||
+                !keyValPair.get(Constants.Device.SERIAL).toString().equals(deviceInfo.getDeviceSerialNumber())) {
             property = new Device.Property();
             property.setName(Constants.Device.SERIAL);
             property.setValue(deviceInfo.getDeviceSerialNumber());
@@ -167,17 +163,20 @@ public class DeviceInfoPayload {
             keyValPair.put(Constants.Device.SERIAL, deviceInfo.getDeviceSerialNumber().toString());
         }
 
-        if ((keyValPair.get(Constants.Device.IMEI) == null) || (keyValPair.get(Constants.Device.IMEI) != null
-                && !keyValPair.get(Constants.Device.IMEI).toString().equals(telephonyManager.getDeviceId().toString()))) {
-            property = new Device.Property();
-            property.setName(Constants.Device.IMEI);
-            property.setValue(telephonyManager.getDeviceId());
-            properties.add(property);
-            keyValPair.put(Constants.Device.IMEI, telephonyManager.getDeviceId().toString());
+        if (ActivityCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE)
+                == PackageManager.PERMISSION_GRANTED) {
+            if ((keyValPair.get(Constants.Device.IMEI) == null) || !keyValPair.get(Constants.Device.IMEI).toString()
+                    .equals(telephonyManager.getDeviceId().toString())) {
+                property = new Device.Property();
+                property.setName(Constants.Device.IMEI);
+                property.setValue(telephonyManager.getDeviceId());
+                properties.add(property);
+                keyValPair.put(Constants.Device.IMEI, telephonyManager.getDeviceId().toString());
+            }
         }
 
-        if ((keyValPair.get(Constants.Device.IMSI) == null) || (keyValPair.get(Constants.Device.IMSI) != null
-                && !keyValPair.get(Constants.Device.IMSI).toString().equals(deviceInfo.getIMSINumber().toString()))) {
+        if ((keyValPair.get(Constants.Device.IMSI) == null) ||
+                !keyValPair.get(Constants.Device.IMSI).toString().equals(deviceInfo.getIMSINumber().toString())) {
             property = new Device.Property();
             property.setName(Constants.Device.IMSI);
             property.setValue(deviceInfo.getIMSINumber());
@@ -185,8 +184,8 @@ public class DeviceInfoPayload {
             keyValPair.put(Constants.Device.IMSI, deviceInfo.getIMSINumber().toString());
         }
 
-        if ((keyValPair.get(Constants.Device.MAC) == null) || (keyValPair.get(Constants.Device.MAC) != null
-                && !keyValPair.get(Constants.Device.MAC).toString().equals(deviceInfo.getMACAddress()))) {
+        if ((keyValPair.get(Constants.Device.MAC) == null) ||
+                !keyValPair.get(Constants.Device.MAC).toString().equals(deviceInfo.getMACAddress())) {
             property = new Device.Property();
             property.setName(Constants.Device.MAC);
             property.setValue(deviceInfo.getMACAddress());
@@ -194,8 +193,9 @@ public class DeviceInfoPayload {
             keyValPair.put(Constants.Device.MAC, deviceInfo.getMACAddress().toString());
         }
 
-        if ((keyValPair.get(Constants.Device.MODEL) == null) || (keyValPair.get(Constants.Device.MODEL) != null
-                && !keyValPair.get(Constants.Device.MODEL).toString().equals(deviceInfo.getDeviceModel().toString()))) {
+        if ((keyValPair.get(Constants.Device.MODEL) == null) ||
+                !keyValPair.get(Constants.Device.MODEL).toString()
+                        .equals(deviceInfo.getDeviceModel().toString())) {
             property = new Device.Property();
             property.setName(Constants.Device.MODEL);
             property.setValue(deviceInfo.getDeviceModel());
@@ -203,8 +203,9 @@ public class DeviceInfoPayload {
             keyValPair.put(Constants.Device.MODEL, deviceInfo.getDeviceModel().toString());
         }
 
-        if ((keyValPair.get(Constants.Device.VENDOR) == null) || (keyValPair.get(Constants.Device.VENDOR) != null
-                && !keyValPair.get(Constants.Device.VENDOR).toString().equals(deviceInfo.getDeviceManufacturer().toString()))) {
+        if ((keyValPair.get(Constants.Device.VENDOR) == null) ||
+                !keyValPair.get(Constants.Device.VENDOR).toString()
+                        .equals(deviceInfo.getDeviceManufacturer().toString())) {
             property = new Device.Property();
             property.setName(Constants.Device.VENDOR);
             property.setValue(deviceInfo.getDeviceManufacturer());
@@ -212,8 +213,8 @@ public class DeviceInfoPayload {
             keyValPair.put(Constants.Device.VENDOR, deviceInfo.getDeviceManufacturer().toString());
         }
 
-        if ((keyValPair.get(Constants.Device.OS) == null) || (keyValPair.get(Constants.Device.OS) != null
-                && !keyValPair.get(Constants.Device.OS).toString().equals(deviceInfo.getOsVersion().toString()))) {
+        if ((keyValPair.get(Constants.Device.OS) == null)
+                || !keyValPair.get(Constants.Device.OS).toString().equals(deviceInfo.getOsVersion().toString())) {
             property = new Device.Property();
             property.setName(Constants.Device.OS);
             property.setValue(deviceInfo.getOsVersion());
@@ -221,8 +222,9 @@ public class DeviceInfoPayload {
             keyValPair.put(Constants.Device.OS, deviceInfo.getOsVersion().toString());
         }
 
-        if ((keyValPair.get(Constants.Device.OS_BUILD_DATE) == null) || (keyValPair.get(Constants.Device.OS_BUILD_DATE) != null
-                && !keyValPair.get(Constants.Device.OS_BUILD_DATE).toString().equals(deviceInfo.getOSBuildDate().toString()))) {
+        if ((keyValPair.get(Constants.Device.OS_BUILD_DATE) == null)
+                || !keyValPair.get(Constants.Device.OS_BUILD_DATE).toString()
+                .equals(deviceInfo.getOSBuildDate().toString())) {
             property = new Device.Property();
             property.setName(Constants.Device.OS_BUILD_DATE);
             property.setValue(deviceInfo.getOSBuildDate());
@@ -230,8 +232,8 @@ public class DeviceInfoPayload {
             keyValPair.put(Constants.Device.OS_BUILD_DATE, deviceInfo.getOSBuildDate().toString());
         }
 
-        if ((keyValPair.get(Constants.Device.NAME) == null) || (keyValPair.get(Constants.Device.NAME) != null
-                && !keyValPair.get(Constants.Device.NAME).toString().equals(deviceInfo.getDeviceName().toString()))) {
+        if ((keyValPair.get(Constants.Device.NAME) == null)
+                || !keyValPair.get(Constants.Device.NAME).toString().equals(deviceInfo.getDeviceName().toString())) {
             property = new Device.Property();
             property.setName(Constants.Device.NAME);
             property.setValue(deviceInfo.getDeviceName());
@@ -244,8 +246,9 @@ public class DeviceInfoPayload {
             double longitude = deviceLocation.getLongitude();
 
             if (latitude != 0 && longitude != 0) {
-                if ((keyValPair.get(Constants.Device.MOBILE_DEVICE_LATITUDE) == null) || (keyValPair.get(Constants.Device.MOBILE_DEVICE_LATITUDE) != null
-                        && !keyValPair.get(Constants.Device.MOBILE_DEVICE_LATITUDE).toString().equals(String.valueOf(latitude)))) {
+                if ((keyValPair.get(Constants.Device.MOBILE_DEVICE_LATITUDE) == null)
+                        || !keyValPair.get(Constants.Device.MOBILE_DEVICE_LATITUDE).toString()
+                        .equals(String.valueOf(latitude))) {
                     property = new Device.Property();
                     property.setName(Constants.Device.MOBILE_DEVICE_LATITUDE);
                     property.setValue(String.valueOf(latitude));
@@ -253,8 +256,9 @@ public class DeviceInfoPayload {
                     keyValPair.put(Constants.Device.MOBILE_DEVICE_LATITUDE, String.valueOf(latitude));
                 }
 
-                if ((keyValPair.get(Constants.Device.MOBILE_DEVICE_LONGITUDE) == null) || (keyValPair.get(Constants.Device.MOBILE_DEVICE_LONGITUDE) != null
-                        && !keyValPair.get(Constants.Device.MOBILE_DEVICE_LONGITUDE).toString().equals(String.valueOf(longitude)))) {
+                if ((keyValPair.get(Constants.Device.MOBILE_DEVICE_LONGITUDE) == null)
+                        || !keyValPair.get(Constants.Device.MOBILE_DEVICE_LONGITUDE).toString()
+                        .equals(String.valueOf(longitude))) {
                     property = new Device.Property();
                     property.setName(Constants.Device.MOBILE_DEVICE_LONGITUDE);
                     property.setValue(String.valueOf(longitude));
@@ -265,8 +269,9 @@ public class DeviceInfoPayload {
         }
 
         if (registrationId != null) {
-            if ((keyValPair.get(Constants.Device.FCM_TOKEN) == null) || (keyValPair.get(Constants.Device.FCM_TOKEN) != null
-                    && !keyValPair.get(Constants.Device.FCM_TOKEN).toString().equals(deviceInfo.getIMSINumber().toString()))) {
+            if ((keyValPair.get(Constants.Device.FCM_TOKEN) == null)
+                    || !keyValPair.get(Constants.Device.FCM_TOKEN).toString()
+                    .equals(registrationId)) {
                 property = new Device.Property();
                 property.setName(Constants.Device.FCM_TOKEN);
                 property.setValue(registrationId);
@@ -277,80 +282,128 @@ public class DeviceInfoPayload {
 
         List<Device.Property> deviceInfoProperties = new ArrayList<>();
 
-        property = new Device.Property();
-        property.setName(Constants.Device.ENCRYPTION_STATUS);
-        property.setValue(String.valueOf(deviceInfo.isEncryptionEnabled()));
-        deviceInfoProperties.add(property);
-
-        if ((deviceInfo.getSdkVersion() >= Build.VERSION_CODES.LOLLIPOP)) {
+        if ((keyValPair.get(Constants.Device.ENCRYPTION_STATUS) == null) || !keyValPair
+                .get(Constants.Device.ENCRYPTION_STATUS).toString()
+                .equals(String.valueOf(deviceInfo.isEncryptionEnabled()))) {
             property = new Device.Property();
-            property.setName(Constants.Device.PASSCODE_STATUS);
-            property.setValue(String.valueOf(deviceInfo.isPasscodeEnabled()));
+            property.setName(Constants.Device.ENCRYPTION_STATUS);
+            property.setValue(String.valueOf(deviceInfo.isEncryptionEnabled()));
             deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.ENCRYPTION_STATUS, String.valueOf(deviceInfo.isEncryptionEnabled()));
         }
 
-        property = new Device.Property();
-        property.setName(Constants.Device.BATTERY_LEVEL);
-        int batteryLevel = Math.round(power.getLevel());
-        property.setValue(String.valueOf(batteryLevel));
-        deviceInfoProperties.add(property);
-        keyValPair.put(Constants.Device.BATTERY_LEVEL, String.valueOf(batteryLevel));
+        if ((deviceInfo.getSdkVersion() >= Build.VERSION_CODES.LOLLIPOP)) {
+            if ((keyValPair.get(Constants.Device.PASSCODE_STATUS) == null) || !keyValPair
+                    .get(Constants.Device.PASSCODE_STATUS).toString()
+                    .equals(String.valueOf(deviceInfo.isPasscodeEnabled()))) {
+                property = new Device.Property();
+                property.setName(Constants.Device.PASSCODE_STATUS);
+                property.setValue(String.valueOf(deviceInfo.isPasscodeEnabled()));
+                deviceInfoProperties.add(property);
+                keyValPair.put(Constants.Device.PASSCODE_STATUS, String.valueOf(deviceInfo.isPasscodeEnabled()));
+            }
+        }
 
-        property = new Device.Property();
-        property.setName(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL);
-        property.setValue(String.valueOf(phoneState.getTotalInternalMemorySize()));
-        deviceInfoProperties.add(property);
-        keyValPair.put(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL, String.valueOf(phoneState.getTotalInternalMemorySize()));
+        if ((keyValPair.get(Constants.Device.BATTERY_LEVEL) == null) ||
+                !keyValPair.get(Constants.Device.BATTERY_LEVEL).toString()
+                        .equals(String.valueOf(Math.round(power.getLevel())))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.BATTERY_LEVEL);
+            int batteryLevel = Math.round(power.getLevel());
+            property.setValue(String.valueOf(batteryLevel));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.BATTERY_LEVEL, String.valueOf(batteryLevel));
+        }
 
-        property = new Device.Property();
-        property.setName(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE);
-        property.setValue(String.valueOf(phoneState.getAvailableInternalMemorySize()));
-        deviceInfoProperties.add(property);
-        keyValPair.put(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE, String.valueOf(phoneState.getAvailableInternalMemorySize()));
+        if ((keyValPair.get(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL) == null) || !keyValPair
+                .get(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL).toString()
+                .equals(String.valueOf(phoneState.getTotalInternalMemorySize()))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL);
+            property.setValue(String.valueOf(phoneState.getTotalInternalMemorySize()));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL,
+                    String.valueOf(phoneState.getTotalInternalMemorySize()));
+        }
 
-        property = new Device.Property();
-        property.setName(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL);
-        property.setValue(String.valueOf(phoneState.getTotalExternalMemorySize()));
-        deviceInfoProperties.add(property);
-        keyValPair.put(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL, String.valueOf(phoneState.getTotalExternalMemorySize()));
+        if ((keyValPair.get(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE) == null) || !keyValPair
+                .get(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE).toString()
+                .equals(String.valueOf(phoneState.getAvailableInternalMemorySize()))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE);
+            property.setValue(String.valueOf(phoneState.getAvailableInternalMemorySize()));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE,
+                    String.valueOf(phoneState.getAvailableInternalMemorySize()));
+        }
 
-        property = new Device.Property();
-        property.setName(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE);
-        property.setValue(String.valueOf(phoneState.getAvailableExternalMemorySize()));
-        deviceInfoProperties.add(property);
-        keyValPair.put(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE, String.valueOf(phoneState.getAvailableExternalMemorySize()));
+        if ((keyValPair.get(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL) == null) || !keyValPair
+                .get(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL).toString()
+                .equals(String.valueOf(phoneState.getTotalExternalMemorySize()))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL);
+            property.setValue(String.valueOf(phoneState.getTotalExternalMemorySize()));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL,
+                    String.valueOf(phoneState.getTotalExternalMemorySize()));
+        }
 
-        property = new Device.Property();
-        property.setName(Constants.Device.NETWORK_OPERATOR);
-        property.setValue(String.valueOf(deviceInfo.getNetworkOperatorName()));
-        deviceInfoProperties.add(property);
-        keyValPair.put(Constants.Device.NETWORK_OPERATOR, String.valueOf(deviceInfo.getNetworkOperatorName()));
+        if ((keyValPair.get(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE) == null) || !keyValPair
+                .get(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE).toString()
+                .equals(String.valueOf(phoneState.getAvailableExternalMemorySize()))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE);
+            property.setValue(String.valueOf(phoneState.getAvailableExternalMemorySize()));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE,
+                    String.valueOf(phoneState.getAvailableExternalMemorySize()));
+        }
 
-        if (telephonyManager != null
-                && ActivityCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED) {
+        if ((keyValPair.get(Constants.Device.NETWORK_OPERATOR) == null) || !keyValPair
+                .get(Constants.Device.NETWORK_OPERATOR).toString()
+                .equals(String.valueOf(deviceInfo.getNetworkOperatorName()))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.NETWORK_OPERATOR);
+            property.setValue(String.valueOf(deviceInfo.getNetworkOperatorName()));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.NETWORK_OPERATOR,
+                    String.valueOf(deviceInfo.getNetworkOperatorName()));
+        }
+        if (telephonyManager != null && ActivityCompat
+                .checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE)
+                == PackageManager.PERMISSION_GRANTED) {
             String mPhoneNumber = telephonyManager.getLine1Number();
-            if (mPhoneNumber != null) {
+
+            if ((mPhoneNumber != null) && (keyValPair.get(Constants.Device.PHONE_NUMBER) == null) || !keyValPair
+                    .get(Constants.Device.PHONE_NUMBER).toString().equals(mPhoneNumber)) {
                 property = new Device.Property();
                 property.setName(Constants.Device.PHONE_NUMBER);
                 property.setValue(mPhoneNumber);
                 deviceInfoProperties.add(property);
+                keyValPair.put(Constants.Device.PHONE_NUMBER, mPhoneNumber);
             }
         }
 
         try {
             String network = NetworkInfoService.getNetworkStatus();
-            if (network != null) {
+            if ((network != null) && (keyValPair.get(Constants.Device.NETWORK_INFO) == null) || !keyValPair
+                    .get(Constants.Device.NETWORK_INFO).toString().equals(network)) {
                 property = new Device.Property();
                 property.setName(Constants.Device.NETWORK_INFO);
                 property.setValue(network);
                 properties.add(property);
+                keyValPair.put(Constants.Device.NETWORK_INFO, network);
             }
             if (Constants.WIFI_SCANNING_ENABLED) {
-                // adding wifi scan results..
-                property = new Device.Property();
-                property.setName(Constants.Device.WIFI_SCAN_RESULT);
-                property.setValue(NetworkInfoService.getWifiScanResult());
-                properties.add(property);
+                String wifiScanResult = NetworkInfoService.getWifiScanResult(context);
+                if ((network != null) && (keyValPair.get(Constants.Device.WIFI_SCAN_RESULT) == null) || !keyValPair
+                        .get(Constants.Device.WIFI_SCAN_RESULT).toString().equals(wifiScanResult)) {
+                    property = new Device.Property();
+                    property.setName(Constants.Device.WIFI_SCAN_RESULT);
+                    property.setValue(wifiScanResult);
+                    properties.add(property);
+                    keyValPair.put(Constants.Device.WIFI_SCAN_RESULT, wifiScanResult);
+                }
             }
         } catch (AndroidAgentException e) {
             Log.e(TAG, "Error retrieving network status. " + e.getMessage());
@@ -366,8 +419,8 @@ public class DeviceInfoPayload {
             throw new AndroidAgentException(errorMsg, e);
         }
 
-        if ((keyValPair.get(Constants.Device.CPU_INFO) == null) || (keyValPair.get(Constants.Device.CPU_INFO) != null
-                && !keyValPair.get(Constants.Device.CPU_INFO).toString().equals(cpuInfoPayload))) {
+        if ((keyValPair.get(Constants.Device.CPU_INFO) == null) ||
+                !keyValPair.get(Constants.Device.CPU_INFO).toString().equals(cpuInfoPayload)) {
             property = new Device.Property();
             property.setName(Constants.Device.CPU_INFO);
             property.setValue(cpuInfoPayload);
@@ -435,8 +488,8 @@ public class DeviceInfoPayload {
             throw new AndroidAgentException(errorMsg, e);
         }
 
-        if ((keyValPair.get(Constants.Device.BATTERY_INFO) == null) || (keyValPair.get(Constants.Device.BATTERY_INFO) != null
-                && !keyValPair.get(Constants.Device.BATTERY_INFO).toString().equals(batteryInfoPayload))) {
+        if ((keyValPair.get(Constants.Device.BATTERY_INFO) == null) ||
+                !keyValPair.get(Constants.Device.BATTERY_INFO).toString().equals(batteryInfoPayload)) {
             property = new Device.Property();
             property.setName(Constants.Device.BATTERY_INFO);
             property.setValue(batteryInfoPayload);
@@ -453,23 +506,23 @@ public class DeviceInfoPayload {
             Log.e(TAG, errorMsg, e);
             throw new AndroidAgentException(errorMsg, e);
         }
-        if ((keyValPair.get(Constants.Device.INFO) == null) || (keyValPair.get(Constants.Device.INFO) != null
-                && !keyValPair.get(Constants.Device.INFO).toString().equals(deviceInfoPayload))) {
+
+        if ((keyValPair.get(Constants.Device.INFO) == null) || !keyValPair
+                .get(Constants.Device.INFO).toString().equals(deviceInfoPayload)) {
             property = new Device.Property();
             property.setName(Constants.Device.INFO);
             property.setValue(deviceInfoPayload);
             properties.add(property);
             keyValPair.put(Constants.Device.INFO, deviceInfoPayload);
         }
+
         device.setProperties(properties);
         ByteArrayOutputStream bao = new ByteArrayOutputStream();
         try {
             ObjectOutputStream oos = new ObjectOutputStream(bao);
             oos.writeObject(keyValPair);
             String stringObject = null;
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.FROYO) {
-                stringObject = Base64.encodeToString(bao.toByteArray(), Base64.DEFAULT);
-            }
+            stringObject = Base64.encodeToString(bao.toByteArray(), Base64.DEFAULT);
             Preference.putString(context, "lastDeviceObject", stringObject);
         } catch (IOException e) {
             throw new AndroidAgentException("Error occurred while serializing policy operation object", e);

--- a/client/client/src/main/java/org/wso2/iot/agent/services/NetworkInfoService.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/services/NetworkInfoService.java
@@ -235,8 +235,8 @@ public class NetworkInfoService extends Service {
     public static String getWifiScanResult(Context context) throws AndroidAgentException {
         if (wifiScanResults != null) {
             Map<String, Integer> wifiScanResultsMap = null;
-            if (Preference.getString(context, "lastWifiScanResultsMap") != null) {
-                String lastUpdatedInfoString = Preference.getString(context, "lastWifiScanResultsMap");
+            if (Preference.getString(context, Constants.LAST_WIFI_SCAN_RESULT_SHARED_PREF) != null) {
+                String lastUpdatedInfoString = Preference.getString(context, Constants.LAST_WIFI_SCAN_RESULT_SHARED_PREF);
                 byte[] lastUpdatedInfoByteArray = Base64.decode(lastUpdatedInfoString, Base64.DEFAULT);
                 ByteArrayInputStream bais = new ByteArrayInputStream(lastUpdatedInfoByteArray);
                 ObjectInputStream ois = null;
@@ -279,7 +279,7 @@ public class NetworkInfoService extends Service {
                     oos.writeObject(wifiScanResultsMap);
                     String stringObject = null;
                     stringObject = Base64.encodeToString(bao.toByteArray(), Base64.DEFAULT);
-                    Preference.putString(context, "lastWifiScanResultsMap", stringObject);
+                    Preference.putString(context, Constants.LAST_WIFI_SCAN_RESULT_SHARED_PREF, stringObject);
                 } catch (IOException e) {
                     throw new AndroidAgentException("Error occurred while serializing lastWifiScanResultsMap object", e);
                 }

--- a/client/client/src/main/java/org/wso2/iot/agent/utils/CommonUtils.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/utils/CommonUtils.java
@@ -40,6 +40,7 @@ import android.util.Base64;
 import android.util.Log;
 import android.widget.Toast;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -259,6 +260,7 @@ public class CommonUtils {
 	public static String toJSON (Object obj) throws AndroidAgentException {
 		try {
 			ObjectMapper mapper = new ObjectMapper();
+			mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 			return mapper.writeValueAsString(obj);
 		} catch (JsonMappingException e) {
 			throw new AndroidAgentException("Error occurred while mapping class to json", e);

--- a/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
@@ -221,6 +221,8 @@ public class Constants {
 	 */
 	public static final String LAST_DEVICE_INFO_SHARED_PREF = "lastDeviceObject";
 	public static final String LAST_WIFI_SCAN_RESULT_SHARED_PREF = "lastWifiScanResultsMap";
+	public static final String LAST_APP_LIST_SHARED_PREF = "lastApplicationList";
+	public static final String NO_APPLIST_CHANGE = "SAME_APPLICATION_LIST";
 
 	/**
 	 * HTTP clients

--- a/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
@@ -217,6 +217,12 @@ public class Constants {
 	public static final boolean FCM_FALLBACK_PULL_ENABLED = BuildConfig.FCM_FALLBACK_PULL_ENABLED;
 
 	/**
+	 * Device info payload.
+	 */
+	public static final String LAST_DEVICE_INFO_SHARED_PREF = "lastDeviceObject";
+	public static final String LAST_WIFI_SCAN_RESULT_SHARED_PREF = "lastWifiScanResultsMap";
+
+	/**
 	 * HTTP clients
 	 */
 	public final class RetryPolicy {

--- a/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
@@ -484,6 +484,8 @@ public class Constants {
 		public static final String PID = "PID";
 		public static final String SHARED_DIRTY = "SHARED_DIRTY";
 		public static final String PHONE_NUMBER = "PHONE_NUMBER";
+		public static final String DEVICE_IDENTIFIERE = "DEVICE_IDENTIFIERE";
+		public static final String DEVICE_NAME = "DEVICE_NAME";
 
 		private Device() {
 			throw new AssertionError();

--- a/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/iot/agent/utils/Constants.java
@@ -484,7 +484,7 @@ public class Constants {
 		public static final String PID = "PID";
 		public static final String SHARED_DIRTY = "SHARED_DIRTY";
 		public static final String PHONE_NUMBER = "PHONE_NUMBER";
-		public static final String DEVICE_IDENTIFIERE = "DEVICE_IDENTIFIERE";
+		public static final String DEVICE_IDENTIFIER = "DEVICE_IDENTIFIER";
 		public static final String DEVICE_NAME = "DEVICE_NAME";
 
 		private Device() {


### PR DESCRIPTION
## Purpose
> Reduce the size of the device info payload by removing unchanged information comparing with the previously sent data.

## Approach
> In the android agent create a Map, Which is storing key-value pairs for the attributes contains in the response payload and store that object in the shared preference. 
> At the time device info payload build, Compare the new values with the previous one and if changed add that to the device_info payload.
