### PR TITLE
Reducing DEVICE_INFO payload size by avoiding unchanged properties

### DIFF
--- a/client/client/src/main/java/org/wso2/emm/agent/beans/Device.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/beans/Device.java
@@ -17,6 +17,7 @@
 
 package org.wso2.emm.agent.beans;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,6 +32,7 @@ import java.util.List;
  * This class represents the basic information of
  * the carbon-device-mgt supported device
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Device {
 
 	private String description;

--- a/client/client/src/main/java/org/wso2/emm/agent/services/DeviceInfoPayload.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/DeviceInfoPayload.java
@@ -17,14 +17,20 @@
  */
 package org.wso2.emm.agent.services;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.location.Location;
 import android.os.Build;
+import android.support.v4.app.ActivityCompat;
 import android.telephony.PhoneStateListener;
 import android.telephony.TelephonyManager;
+import android.util.Base64;
 import android.util.Log;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.wso2.emm.agent.AndroidAgentException;
 import org.wso2.emm.agent.api.DeviceInfo;
 import org.wso2.emm.agent.api.DeviceState;
@@ -36,8 +42,16 @@ import org.wso2.emm.agent.services.location.impl.LocationServiceImpl;
 import org.wso2.emm.agent.utils.Constants;
 import org.wso2.emm.agent.utils.Preference;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
 
 /**
  * This class handles building of the device information payload to be sent to the server.
@@ -73,7 +87,7 @@ public class DeviceInfoPayload {
         //setting up basic details of the device
         info.setOwner(owner);
         info.setOwnership(type.equals(Constants.OWNERSHIP_BYOD) ? Device.EnrolmentInfo.OwnerShip.BYOD
-                                                                : Device.EnrolmentInfo.OwnerShip.COPE);
+                : Device.EnrolmentInfo.OwnerShip.COPE);
         device.setEnrolmentInfo(info);
         getInfo();
     }
@@ -90,10 +104,28 @@ public class DeviceInfoPayload {
 
     /**
      * Fetch all device runtime information.
+     *
      * @throws AndroidAgentException
      */
     private void getInfo() throws AndroidAgentException {
 
+        HashMap<String, String> keyValPair = null;
+        if (Preference.getString(context, Constants.LAST_DEVICE_INFO_SHARED_PREF) != null) {
+            String lastUpdatedInfoString = Preference.getString(context, Constants.LAST_DEVICE_INFO_SHARED_PREF);
+            byte[] lastUpdatedInfoByteArray = Base64.decode(lastUpdatedInfoString, Base64.DEFAULT);
+            ByteArrayInputStream bais = new ByteArrayInputStream(lastUpdatedInfoByteArray);
+            ObjectInputStream ois = null;
+            try {
+                ois = new ObjectInputStream(bais);
+                keyValPair = (HashMap<String, String>) ois.readObject();
+            } catch (IOException e) {
+                throw new AndroidAgentException("Error occurred while deserialize Device object", e);
+            } catch (ClassNotFoundException e) {
+                throw new AndroidAgentException("Error occurred while casting to Device object", e);
+            }
+        } else {
+            keyValPair = new HashMap<String, String>();
+        }
         TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
         Location deviceLocation = locationService.getLastKnownLocation();
         if (device == null) {
@@ -102,124 +134,202 @@ public class DeviceInfoPayload {
         deviceInfo = new DeviceInfo(context);
         Power power = phoneState.getBatteryDetails();
         device.setDeviceIdentifier(deviceInfo.getDeviceId());
+        keyValPair.put(Constants.Device.DEVICE_IDENTIFIER, deviceInfo.getDeviceId());
         device.setDescription(deviceInfo.getDeviceName());
         device.setName(deviceInfo.getDeviceName());
+        keyValPair.put(Constants.Device.DEVICE_NAME, deviceInfo.getDeviceName());
 
         List<Device.Property> properties = new ArrayList<>();
-
-        Device.Property property = new Device.Property();
-        property.setName(Constants.Device.SERIAL);
-        property.setValue(deviceInfo.getDeviceSerialNumber());
-        properties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.IMEI);
-        property.setValue(telephonyManager.getDeviceId());
-        properties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.IMSI);
-        property.setValue(deviceInfo.getIMSINumber());
-        properties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.MAC);
-        property.setValue(deviceInfo.getMACAddress());
-        properties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.MODEL);
-        property.setValue(deviceInfo.getDeviceModel());
-        properties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.VENDOR);
-        property.setValue(deviceInfo.getDeviceManufacturer());
-        properties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.OS);
-        property.setValue(deviceInfo.getOsVersion());
-        properties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.OS_BUILD_DATE);
-        property.setValue(deviceInfo.getOSBuildDate());
-        properties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.NAME);
-        property.setValue(deviceInfo.getDeviceName());
-        properties.add(property);
+        Device.Property property = null;
+        if ((keyValPair.get(Constants.Device.SERIAL) == null) ||
+                !keyValPair.get(Constants.Device.SERIAL).toString().equals(deviceInfo.getDeviceSerialNumber())) {
+            property = new Device.Property();
+            property.setName(Constants.Device.SERIAL);
+            property.setValue(deviceInfo.getDeviceSerialNumber());
+            properties.add(property);
+            keyValPair.put(Constants.Device.SERIAL, deviceInfo.getDeviceSerialNumber().toString());
+        }
+        if (ActivityCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE)
+                == PackageManager.PERMISSION_GRANTED) {
+            if ((keyValPair.get(Constants.Device.IMEI) == null) || !keyValPair.get(Constants.Device.IMEI).toString()
+                    .equals(telephonyManager.getDeviceId())) {
+                property = new Device.Property();
+                property.setName(Constants.Device.IMEI);
+                property.setValue(telephonyManager.getDeviceId());
+                properties.add(property);
+                keyValPair.put(Constants.Device.IMEI, telephonyManager.getDeviceId());
+            }
+        }
+        if ((keyValPair.get(Constants.Device.IMSI) == null) ||
+                !keyValPair.get(Constants.Device.IMSI).toString().equals(deviceInfo.getIMSINumber())) {
+            property = new Device.Property();
+            property.setName(Constants.Device.IMSI);
+            property.setValue(deviceInfo.getIMSINumber());
+            properties.add(property);
+            keyValPair.put(Constants.Device.IMSI, deviceInfo.getIMSINumber());
+        }
+        if ((keyValPair.get(Constants.Device.MAC) == null) ||
+                !keyValPair.get(Constants.Device.MAC).toString().equals(deviceInfo.getMACAddress())) {
+            property = new Device.Property();
+            property.setName(Constants.Device.MAC);
+            property.setValue(deviceInfo.getMACAddress());
+            properties.add(property);
+            keyValPair.put(Constants.Device.MAC, deviceInfo.getMACAddress());
+        }
+        if ((keyValPair.get(Constants.Device.MODEL) == null) ||
+                !keyValPair.get(Constants.Device.MODEL).toString()
+                        .equals(deviceInfo.getDeviceModel())) {
+            property = new Device.Property();
+            property.setName(Constants.Device.MODEL);
+            property.setValue(deviceInfo.getDeviceModel());
+            properties.add(property);
+            keyValPair.put(Constants.Device.MODEL, deviceInfo.getDeviceModel());
+        }
+        if ((keyValPair.get(Constants.Device.VENDOR) == null) ||
+                !keyValPair.get(Constants.Device.VENDOR).toString()
+                        .equals(deviceInfo.getDeviceManufacturer())) {
+            property = new Device.Property();
+            property.setName(Constants.Device.VENDOR);
+            property.setValue(deviceInfo.getDeviceManufacturer());
+            properties.add(property);
+            keyValPair.put(Constants.Device.VENDOR, deviceInfo.getDeviceManufacturer());
+        }
+        if ((keyValPair.get(Constants.Device.OS) == null)
+                || !keyValPair.get(Constants.Device.OS).toString().equals(deviceInfo.getOsVersion())) {
+            property = new Device.Property();
+            property.setName(Constants.Device.OS);
+            property.setValue(deviceInfo.getOsVersion());
+            properties.add(property);
+            keyValPair.put(Constants.Device.OS, deviceInfo.getOsVersion());
+        }
+        if ((keyValPair.get(Constants.Device.OS_BUILD_DATE) == null)
+                || !keyValPair.get(Constants.Device.OS_BUILD_DATE).toString()
+                .equals(deviceInfo.getOSBuildDate())) {
+            property = new Device.Property();
+            property.setName(Constants.Device.OS_BUILD_DATE);
+            property.setValue(deviceInfo.getOSBuildDate());
+            properties.add(property);
+            keyValPair.put(Constants.Device.OS_BUILD_DATE, deviceInfo.getOSBuildDate());
+        }
+        if ((keyValPair.get(Constants.Device.NAME) == null)
+                || !keyValPair.get(Constants.Device.NAME).toString().equals(deviceInfo.getDeviceName())) {
+            property = new Device.Property();
+            property.setName(Constants.Device.NAME);
+            property.setValue(deviceInfo.getDeviceName());
+            properties.add(property);
+            keyValPair.put(Constants.Device.NAME, deviceInfo.getDeviceName());
+        }
 
         if (deviceLocation != null) {
             double latitude = deviceLocation.getLatitude();
             double longitude = deviceLocation.getLongitude();
 
             if (latitude != 0 && longitude != 0) {
-                property = new Device.Property();
-                property.setName(Constants.Device.MOBILE_DEVICE_LATITUDE);
-                property.setValue(String.valueOf(latitude));
-                properties.add(property);
-
-                property = new Device.Property();
-                property.setName(Constants.Device.MOBILE_DEVICE_LONGITUDE);
-                property.setValue(String.valueOf(longitude));
-                properties.add(property);
+                if ((keyValPair.get(Constants.Device.MOBILE_DEVICE_LATITUDE) == null)
+                        || !keyValPair.get(Constants.Device.MOBILE_DEVICE_LATITUDE).toString()
+                        .equals(String.valueOf(latitude))) {
+                    property = new Device.Property();
+                    property.setName(Constants.Device.MOBILE_DEVICE_LATITUDE);
+                    property.setValue(String.valueOf(latitude));
+                    properties.add(property);
+                    keyValPair.put(Constants.Device.MOBILE_DEVICE_LATITUDE, String.valueOf(latitude));
+                }
+                if ((keyValPair.get(Constants.Device.MOBILE_DEVICE_LONGITUDE) == null)
+                        || !keyValPair.get(Constants.Device.MOBILE_DEVICE_LONGITUDE).toString()
+                        .equals(String.valueOf(longitude))) {
+                    property = new Device.Property();
+                    property.setName(Constants.Device.MOBILE_DEVICE_LONGITUDE);
+                    property.setValue(String.valueOf(longitude));
+                    properties.add(property);
+                    keyValPair.put(Constants.Device.MOBILE_DEVICE_LONGITUDE, String.valueOf(longitude));
+                }
             }
-        }
-
-        if (registrationId != null) {
-            property = new Device.Property();
-            property.setName(Constants.Device.GCM_TOKEN);
-            property.setValue(registrationId);
-            properties.add(property);
         }
 
         List<Device.Property> deviceInfoProperties = new ArrayList<>();
 
-        property = new Device.Property();
-        property.setName(Constants.Device.ENCRYPTION_STATUS);
-        property.setValue(String.valueOf(deviceInfo.isEncryptionEnabled()));
-        deviceInfoProperties.add(property);
-
-        if ((deviceInfo.getSdkVersion() >= Build.VERSION_CODES.LOLLIPOP)) {
+        if ((keyValPair.get(Constants.Device.ENCRYPTION_STATUS) == null) || !keyValPair
+                .get(Constants.Device.ENCRYPTION_STATUS).toString()
+                .equals(String.valueOf(deviceInfo.isEncryptionEnabled()))) {
             property = new Device.Property();
-            property.setName(Constants.Device.PASSCODE_STATUS);
-            property.setValue(String.valueOf(deviceInfo.isPasscodeEnabled()));
+            property.setName(Constants.Device.ENCRYPTION_STATUS);
+            property.setValue(String.valueOf(deviceInfo.isEncryptionEnabled()));
             deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.ENCRYPTION_STATUS, String.valueOf(deviceInfo.isEncryptionEnabled()));
         }
 
-        property = new Device.Property();
-        property.setName(Constants.Device.BATTERY_LEVEL);
-        int batteryLevel = Math.round(power.getLevel());
-        property.setValue(String.valueOf(batteryLevel));
-        deviceInfoProperties.add(property);
+        if ((deviceInfo.getSdkVersion() >= Build.VERSION_CODES.LOLLIPOP)) {
+            if ((keyValPair.get(Constants.Device.PASSCODE_STATUS) == null) || !keyValPair
+                    .get(Constants.Device.PASSCODE_STATUS).toString()
+                    .equals(String.valueOf(deviceInfo.isPasscodeEnabled()))) {
+                property = new Device.Property();
+                property.setName(Constants.Device.PASSCODE_STATUS);
+                property.setValue(String.valueOf(deviceInfo.isPasscodeEnabled()));
+                deviceInfoProperties.add(property);
+                keyValPair.put(Constants.Device.PASSCODE_STATUS, String.valueOf(deviceInfo.isPasscodeEnabled()));
+            }
+        }
 
-        property = new Device.Property();
-        property.setName(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL);
-        property.setValue(String.valueOf(phoneState.getTotalInternalMemorySize()));
-        deviceInfoProperties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE);
-        property.setValue(String.valueOf(phoneState.getAvailableInternalMemorySize()));
-        deviceInfoProperties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL);
-        property.setValue(String.valueOf(phoneState.getTotalExternalMemorySize()));
-        deviceInfoProperties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE);
-        property.setValue(String.valueOf(phoneState.getAvailableExternalMemorySize()));
-        deviceInfoProperties.add(property);
-
-        property = new Device.Property();
-        property.setName(Constants.Device.NETWORK_OPERATOR);
-        property.setValue(String.valueOf(deviceInfo.getNetworkOperatorName()));
-        deviceInfoProperties.add(property);
+        if ((keyValPair.get(Constants.Device.BATTERY_LEVEL) == null) ||
+                !keyValPair.get(Constants.Device.BATTERY_LEVEL).toString()
+                        .equals(String.valueOf(Math.round(power.getLevel())))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.BATTERY_LEVEL);
+            int batteryLevel = Math.round(power.getLevel());
+            property.setValue(String.valueOf(batteryLevel));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.BATTERY_LEVEL, String.valueOf(batteryLevel));
+        }
+        if ((keyValPair.get(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL) == null) || !keyValPair
+                .get(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL).toString()
+                .equals(String.valueOf(phoneState.getTotalInternalMemorySize()))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL);
+            property.setValue(String.valueOf(phoneState.getTotalInternalMemorySize()));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.MEMORY_INFO_INTERNAL_TOTAL,
+                    String.valueOf(phoneState.getTotalInternalMemorySize()));
+        }
+        if ((keyValPair.get(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE) == null) || !keyValPair
+                .get(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE).toString()
+                .equals(String.valueOf(phoneState.getAvailableInternalMemorySize()))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE);
+            property.setValue(String.valueOf(phoneState.getAvailableInternalMemorySize()));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.MEMORY_INFO_INTERNAL_AVAILABLE,
+                    String.valueOf(phoneState.getAvailableInternalMemorySize()));
+        }
+        if ((keyValPair.get(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL) == null) || !keyValPair
+                .get(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL).toString()
+                .equals(String.valueOf(phoneState.getTotalExternalMemorySize()))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL);
+            property.setValue(String.valueOf(phoneState.getTotalExternalMemorySize()));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.MEMORY_INFO_EXTERNAL_TOTAL,
+                    String.valueOf(phoneState.getTotalExternalMemorySize()));
+        }
+        if ((keyValPair.get(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE) == null) || !keyValPair
+                .get(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE).toString()
+                .equals(String.valueOf(phoneState.getAvailableExternalMemorySize()))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE);
+            property.setValue(String.valueOf(phoneState.getAvailableExternalMemorySize()));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.MEMORY_INFO_EXTERNAL_AVAILABLE,
+                    String.valueOf(phoneState.getAvailableExternalMemorySize()));
+        }
+        if ((keyValPair.get(Constants.Device.NETWORK_OPERATOR) == null) || !keyValPair
+                .get(Constants.Device.NETWORK_OPERATOR).toString()
+                .equals(String.valueOf(deviceInfo.getNetworkOperatorName()))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.NETWORK_OPERATOR);
+            property.setValue(String.valueOf(deviceInfo.getNetworkOperatorName()));
+            deviceInfoProperties.add(property);
+            keyValPair.put(Constants.Device.NETWORK_OPERATOR,
+                    String.valueOf(deviceInfo.getNetworkOperatorName()));
+        }
 
         DeviceNetworkStatus deviceNetworkStatus = DeviceNetworkStatus.getInstance(context);
         if (deviceNetworkStatus.isConnectedMobile()) {
@@ -227,18 +337,26 @@ public class DeviceInfoPayload {
         }
 
         String network = deviceNetworkStatus.getNetworkStatus();
-        if(network != null) {
+        if ((network != null) && ((keyValPair.get(Constants.Device.NETWORK_INFO) == null) || !keyValPair
+                .get(Constants.Device.NETWORK_INFO).toString().equals(network))) {
             property = new Device.Property();
             property.setName(Constants.Device.NETWORK_INFO);
             property.setValue(network);
             properties.add(property);
+            keyValPair.put(Constants.Device.NETWORK_INFO, network);
         }
 
         // adding wifi scan results..
-        property = new Device.Property();
-        property.setName(Constants.Device.WIFI_SCAN_RESULT);
-        property.setValue(deviceNetworkStatus.getWifiScanResult());
-        properties.add(property);
+        String wifiScanResult = deviceNetworkStatus.getWifiScanResult();
+        if ((network != null) && ((keyValPair.get(Constants.Device.WIFI_SCAN_RESULT) == null) || !keyValPair
+                .get(Constants.Device.WIFI_SCAN_RESULT).toString().equals(wifiScanResult))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.WIFI_SCAN_RESULT);
+            property.setValue(wifiScanResult);
+            properties.add(property);
+            keyValPair.put(Constants.Device.WIFI_SCAN_RESULT, wifiScanResult);
+        }
+
 
         RuntimeInfo runtimeInfo = new RuntimeInfo(context);
         String cpuInfoPayload;
@@ -250,10 +368,14 @@ public class DeviceInfoPayload {
             throw new AndroidAgentException(errorMsg, e);
         }
 
-        property = new Device.Property();
-        property.setName(Constants.Device.CPU_INFO);
-        property.setValue(cpuInfoPayload);
-        properties.add(property);
+        if ((keyValPair.get(Constants.Device.CPU_INFO) == null) ||
+                !keyValPair.get(Constants.Device.CPU_INFO).toString().equals(cpuInfoPayload)) {
+            property = new Device.Property();
+            property.setName(Constants.Device.CPU_INFO);
+            property.setValue(cpuInfoPayload);
+            properties.add(property);
+            keyValPair.put(Constants.Device.CPU_INFO, cpuInfoPayload);
+        }
 
         String ramInfoPayload;
         try {
@@ -264,10 +386,14 @@ public class DeviceInfoPayload {
             throw new AndroidAgentException(errorMsg, e);
         }
 
-        property = new Device.Property();
-        property.setName(Constants.Device.RAM_INFO);
-        property.setValue(ramInfoPayload);
-        properties.add(property);
+        if ((keyValPair.get(Constants.Device.RAM_INFO) == null) || (keyValPair.get(Constants.Device.RAM_INFO) != null
+                && !keyValPair.get(Constants.Device.RAM_INFO).toString().equals(ramInfoPayload))) {
+            property = new Device.Property();
+            property.setName(Constants.Device.RAM_INFO);
+            property.setValue(ramInfoPayload);
+            properties.add(property);
+            keyValPair.put(Constants.Device.RAM_INFO, ramInfoPayload);
+        }
 
         List<Device.Property> batteryProperties = new ArrayList<>();
         property = new Device.Property();
@@ -309,10 +435,14 @@ public class DeviceInfoPayload {
             throw new AndroidAgentException(errorMsg, e);
         }
 
-        property = new Device.Property();
-        property.setName(Constants.Device.BATTERY_INFO);
-        property.setValue(batteryInfoPayload);
-        properties.add(property);
+        if ((keyValPair.get(Constants.Device.BATTERY_INFO) == null) ||
+                !keyValPair.get(Constants.Device.BATTERY_INFO).toString().equals(batteryInfoPayload)) {
+            property = new Device.Property();
+            property.setName(Constants.Device.BATTERY_INFO);
+            property.setValue(batteryInfoPayload);
+            properties.add(property);
+            keyValPair.put(Constants.Device.BATTERY_INFO, batteryInfoPayload);
+        }
 
         // building device info json payload
         String deviceInfoPayload;
@@ -323,12 +453,27 @@ public class DeviceInfoPayload {
             Log.e(TAG, errorMsg, e);
             throw new AndroidAgentException(errorMsg, e);
         }
-        property = new Device.Property();
-        property.setName(Constants.Device.INFO);
-        property.setValue(deviceInfoPayload);
-        properties.add(property);
+        if ((keyValPair.get(Constants.Device.INFO) == null) || !keyValPair
+                .get(Constants.Device.INFO).toString().equals(deviceInfoPayload)) {
+            property = new Device.Property();
+            property.setName(Constants.Device.INFO);
+            property.setValue(deviceInfoPayload);
+            properties.add(property);
+            keyValPair.put(Constants.Device.INFO, deviceInfoPayload);
+        }
 
         device.setProperties(properties);
+
+        ByteArrayOutputStream bao = new ByteArrayOutputStream();
+        try {
+            ObjectOutputStream oos = new ObjectOutputStream(bao);
+            oos.writeObject(keyValPair);
+            String stringObject = null;
+            stringObject = Base64.encodeToString(bao.toByteArray(), Base64.DEFAULT);
+            Preference.putString(context, Constants.LAST_DEVICE_INFO_SHARED_PREF, stringObject);
+        } catch (IOException e) {
+            throw new AndroidAgentException("Error occurred while serializing device info object.", e);
+        }
     }
 
     /**
@@ -338,7 +483,7 @@ public class DeviceInfoPayload {
      */
     public String getDeviceInfoPayload() {
         try {
-            if(Constants.DEBUG_MODE_ENABLED){
+            if (Constants.DEBUG_MODE_ENABLED) {
                 Log.d(TAG, "device info " + device.toJSON());
             }
             return device.toJSON();

--- a/client/client/src/main/java/org/wso2/emm/agent/services/DeviceStartupIntentReceiver.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/services/DeviceStartupIntentReceiver.java
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- * 
+ *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,64 +41,76 @@ import java.util.Locale;
  */
 public class DeviceStartupIntentReceiver extends BroadcastReceiver {
 
-	public static final int DEFAULT_ID = -1;
-	private Resources resources;
+    public static final int DEFAULT_ID = -1;
+    private Resources resources;
     private static final String TAG = "DeviceStartupIntent";
 
-	@Override
-	public void onReceive(final Context context, Intent intent) {
-		this.resources = context.getApplicationContext().getResources();
-		int lastRebootOperationId = Preference.getInt(context, resources.getString(R.string.shared_pref_reboot_op_id));
-		if (lastRebootOperationId != 0) {
-			Preference.putBoolean(context, resources.getString(R.string.shared_pref_reboot_done), true);
-		}
+    @Override
+    public void onReceive(final Context context, Intent intent) {
+        this.resources = context.getApplicationContext().getResources();
+        int lastRebootOperationId = Preference.getInt(context, resources.getString(R.string.shared_pref_reboot_op_id));
+        if (lastRebootOperationId != 0) {
+            Preference.putBoolean(context, resources.getString(R.string.shared_pref_reboot_done), true);
+        }
 
-		setRecurringAlarm(context.getApplicationContext());
-		if(!EventRegistry.eventListeningStarted) {
-			EventRegistry registerEvent = new EventRegistry(context.getApplicationContext());
-			registerEvent.register();
-		}
-	}
+        setRecurringAlarm(context.getApplicationContext());
+        if (!EventRegistry.eventListeningStarted) {
+            EventRegistry registerEvent = new EventRegistry(context.getApplicationContext());
+            registerEvent.register();
+        }
+    }
 
-	/**
-	 * Initiates device notifier on device startup.
-	 * @param context - Application context.
-	 */
-	private void setRecurringAlarm(Context context) {
-		String mode = Preference.getString(context, Constants.PreferenceFlag.NOTIFIER_TYPE);
-		boolean isLocked = Preference.getBoolean(context, Constants.IS_LOCKED);
-		String lockMessage = Preference.getString(context, Constants.LOCK_MESSAGE);
+    /**
+     * Initiates device notifier on device startup.
+     *
+     * @param context - Application context.
+     */
+    private void setRecurringAlarm(Context context) {
+        String mode = Preference.getString(context, Constants.PreferenceFlag.NOTIFIER_TYPE);
+        boolean isLocked = Preference.getBoolean(context, Constants.IS_LOCKED);
+        String lockMessage = Preference.getString(context, Constants.LOCK_MESSAGE);
 
-		if (lockMessage == null || lockMessage.isEmpty()) {
-			lockMessage = resources.getString(R.string.txt_lock_activity);
-		}
+        if (lockMessage == null || lockMessage.isEmpty()) {
+            lockMessage = resources.getString(R.string.txt_lock_activity);
+        }
 
-		if (isLocked) {
+        if (isLocked) {
             Operation lockOperation = new Operation();
-			lockOperation.setId(DEFAULT_ID);
-			lockOperation.setCode(Constants.Operation.DEVICE_LOCK);
-			try {
-				JSONObject payload = new JSONObject();
-				payload.put(Constants.ADMIN_MESSAGE, lockMessage);
-				payload.put(Constants.IS_HARD_LOCK_ENABLED, true);
-				lockOperation.setPayLoad(payload.toString());
-				OperationProcessor operationProcessor = new OperationProcessor(context);
+            lockOperation.setId(DEFAULT_ID);
+            lockOperation.setCode(Constants.Operation.DEVICE_LOCK);
+            try {
+                JSONObject payload = new JSONObject();
+                payload.put(Constants.ADMIN_MESSAGE, lockMessage);
+                payload.put(Constants.IS_HARD_LOCK_ENABLED, true);
+                lockOperation.setPayLoad(payload.toString());
+                OperationProcessor operationProcessor = new OperationProcessor(context);
                 operationProcessor.doTask(lockOperation);
             } catch (AndroidAgentException e) {
                 Log.e(TAG, "Error occurred while executing hard lock operation at the device startup");
             } catch (JSONException e) {
-				Log.e(TAG, "Error occurred while building hard lock operation payload");
-			}
-		}
+                Log.e(TAG, "Error occurred while building hard lock operation payload");
+            }
+        }
 
-		if(mode == null) {
-			mode = Constants.NOTIFIER_LOCAL;
-		}
+        if (mode == null) {
+            mode = Constants.NOTIFIER_LOCAL;
+        }
 
-		if (Preference.getBoolean(context, Constants.PreferenceFlag.REGISTERED) && Constants.NOTIFIER_LOCAL.equals(
-				mode.trim().toUpperCase(Locale.ENGLISH))) {
-			LocalNotification.startPolling(context);
-		}
-	}
+        if (Preference.getBoolean(context, Constants.PreferenceFlag.REGISTERED) && Constants.NOTIFIER_LOCAL.equals(
+                mode.trim().toUpperCase(Locale.ENGLISH))) {
+            LocalNotification.startPolling(context);
+        }
+
+        /**
+         * Clear the device info and wifi info payloads stored in shared preference
+         * when the device restarts.
+         */
+        if (Preference.getString(context, Constants.LAST_DEVICE_INFO_SHARED_PREF) != null) {
+            Preference.putString(context, Constants.LAST_DEVICE_INFO_SHARED_PREF, null);
+        }
+        if (Preference.getString(context, Constants.LAST_WIFI_SCAN_RESULT_SHARED_PREF) != null) {
+            Preference.putString(context, Constants.LAST_WIFI_SCAN_RESULT_SHARED_PREF, null);
+        }
+    }
 
 }

--- a/client/client/src/main/java/org/wso2/emm/agent/utils/CommonUtils.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/utils/CommonUtils.java
@@ -32,6 +32,8 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.util.Base64;
 import android.util.Log;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -269,6 +271,7 @@ public class CommonUtils {
 	public static String toJSON (Object obj) throws AndroidAgentException {
 		try {
 			ObjectMapper mapper = new ObjectMapper();
+			mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 			return mapper.writeValueAsString(obj);
 		} catch (JsonMappingException e) {
 			throw new AndroidAgentException("Error occurred while mapping class to json", e);

--- a/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
+++ b/client/client/src/main/java/org/wso2/emm/agent/utils/Constants.java
@@ -70,6 +70,12 @@ public class Constants {
 	public static final boolean HIDE_ERROR_DIALOG = false;
 
 	/**
+	 * Device info payload.
+	 */
+	public static final String LAST_DEVICE_INFO_SHARED_PREF = "lastDeviceObject";
+	public static final String LAST_WIFI_SCAN_RESULT_SHARED_PREF = "lastWifiScanResultsMap";
+
+	/**
 	 * Log publishers
 	 */
 	public final class LogPublisher {
@@ -352,6 +358,8 @@ public class Constants {
 		public static final String TRIGGER_HEARTBEAT = "TRIGGER_HEARTBEAT";
 		public static final String FIRMWARE_UPGRADE_AUTOMATIC_RETRY = "FIRMWARE_UPGRADE_AUTOMATIC_RETRY";
 		public static final String NOTIFIER_FREQUENCY = "NOTIFIER_FREQUENCY";
+		public static final String DEVICE_IDENTIFIER = "DEVICE_IDENTIFIER";
+		public static final String DEVICE_NAME = "DEVICE_NAME";
 	}
 
 	/**
@@ -410,6 +418,8 @@ public class Constants {
 		public static final String PACKAGE = "PACKAGE";
 		public static final String PID = "PID";
 		public static final String SHARED_DIRTY = "SHARED_DIRTY";
+		public static final String DEVICE_IDENTIFIER = "DEVICE_IDENTIFIER";
+		public static final String DEVICE_NAME = "DEVICE_NAME";
 	}
 
 	// sqlite database related tables


### PR DESCRIPTION
## Purpose
> Reduce the size of the device info payload by removing unchanged information comparing with the previously sent data.

## Approach
> In the android agent create a Map, Which is storing key-value pairs for the attributes contains in the response payload and store that object in the shared preference. 
> At the time device info payload build, Compare the new values with the previous one and if changed add that to the device_info payload.
